### PR TITLE
Add CHANGELOG for v0.0.5 of the plugin. Closes #76

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,9 @@ _What's new?_
 - New tables added to plugin
 
   - gcp_compute_address ([#29](https://github.com/turbot/steampipe-plugin-gcp/issues/29))
+  - gcp_compute_disk ([#47](https://github.com/turbot/steampipe-plugin-gcp/issues/47))
   - gcp_compute_firewall ([#42](https://github.com/turbot/steampipe-plugin-gcp/issues/42))
   - gcp_compute_forwarding_rule ([#53](https://github.com/turbot/steampipe-plugin-gcp/issues/53))
-  - gcp_compute_disk ([#47](https://github.com/turbot/steampipe-plugin-gcp/issues/47))
   - gcp_compute_network ([#43](https://github.com/turbot/steampipe-plugin-gcp/issues/43))
   - gcp_compute_router ([#51](https://github.com/turbot/steampipe-plugin-gcp/issues/51))
   - gcp_compute_snapshot ([#60](https://github.com/turbot/steampipe-plugin-gcp/issues/60))
@@ -31,3 +31,5 @@ _What's new?_
 _Bug fixes_
 
 - Fixed: `gcp_iam_role` table. Updated `included_permissions` field to have details of role grants for list call.
+
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,20 @@
-# CHANGELOG for GCP Plugin for Steampipe
+## v0.0.5 [2021-02-24]
+
+_What's new?_
+
+- New tables added to plugin
+
+  - gcp_compute_address ([#29](https://github.com/turbot/steampipe-plugin-gcp/issues/29))
+  - gcp_compute_firewall ([#42](https://github.com/turbot/steampipe-plugin-gcp/issues/42))
+  - gcp_compute_forwarding_rule ([#53](https://github.com/turbot/steampipe-plugin-gcp/issues/53))
+  - gcp_compute_disk ([#47](https://github.com/turbot/steampipe-plugin-gcp/issues/47))
+  - gcp_compute_network ([#43](https://github.com/turbot/steampipe-plugin-gcp/issues/43))
+  - gcp_compute_router ([#51](https://github.com/turbot/steampipe-plugin-gcp/issues/51))
+  - gcp_compute_snapshot ([#60](https://github.com/turbot/steampipe-plugin-gcp/issues/60))
+
+_Enhancements_
+
+- Added field `location` to resource tables that are not regional with value as `global`
 
 ## v0.0.4 [2021-01-28]
 

--- a/README.md
+++ b/README.md
@@ -6,10 +6,6 @@
   <a aria-label="Steampipe logo" href="https://steampipe.io">
     <img src="https://steampipe.io/images/steampipe_logo_wordmark_padding.svg" height="28">
   </a>
-  <a aria-label="Plugin version" href="https://hub.steampipe.io/plugins/turbot/gcp">
-    <img alt="" src="https://img.shields.io/static/v1?label=turbot/gcp&message=v0.0.3&style=for-the-badge&labelColor=777777&color=F3F1F0">
-  </a>
-  &nbsp;
   <a aria-label="License" href="LICENSE">
     <img alt="" src="https://img.shields.io/static/v1?label=license&message=MPL-2.0&style=for-the-badge&labelColor=777777&color=F3F1F0">
   </a>

--- a/gcp/plugin.go
+++ b/gcp/plugin.go
@@ -24,19 +24,17 @@ func Plugin(ctx context.Context) *plugin.Plugin {
 			ShouldIgnoreError: isNotFoundError([]string{"404", "400"}),
 		},
 		TableMap: map[string]*plugin.Table{
-			"gcp_audit_policy":                    tableGcpAuditPolicy(ctx),
-			"gcp_cloudfunctions_function":         tableGcpCloudfunctionFunction(ctx),
-			"gcp_compute_address":                 tableGcpComputeAddress(ctx),
-			"gcp_compute_firewall":                tableGcpComputeFirewall(ctx),
-			"gcp_compute_forwarding_rule":         tableGcpComputeForwardingRule(ctx),
-			"gcp_compute_global_address":          tableGcpComputeGlobalAddress(ctx),
-			"gcp_compute_global_forwarding_rule":  tableGcpComputeGlobalForwardingRule(ctx),
-			"gcp_compute_image":                   tableGcpComputeImage(ctx),
-			"gcp_compute_instance":                tableGcpComputeInstance(ctx),
+			"gcp_audit_policy":                   tableGcpAuditPolicy(ctx),
+			"gcp_cloudfunctions_function":        tableGcpCloudfunctionFunction(ctx),
+			"gcp_compute_address":                tableGcpComputeAddress(ctx),
+			"gcp_compute_firewall":               tableGcpComputeFirewall(ctx),
+			"gcp_compute_forwarding_rule":        tableGcpComputeForwardingRule(ctx),
+			"gcp_compute_global_address":         tableGcpComputeGlobalAddress(ctx),
+			"gcp_compute_global_forwarding_rule": tableGcpComputeGlobalForwardingRule(ctx),
+			"gcp_compute_disk":                   tableGcpComputeDisk(ctx), "gcp_compute_instance": tableGcpComputeInstance(ctx),
 			"gcp_compute_network":                 tableGcpComputeNetwork(ctx),
 			"gcp_compute_router":                  tableGcpComputeRouter(ctx),
 			"gcp_compute_snapshot":                tableGcpComputeSnapshot(ctx),
-			"gcp_compute_vpn_tunnel":              tableGcpComputeVpnTunnel(ctx),
 			"gcp_iam_policy":                      tableGcpIAMPolicy(ctx),
 			"gcp_iam_role":                        tableGcpIamRole(ctx),
 			"gcp_logging_exclusion":               tableGcpLoggingExclusion(ctx),
@@ -52,8 +50,15 @@ func Plugin(ctx context.Context) *plugin.Plugin {
 			"gcp_service_account_key":             tableGcpServiceAccountKey(ctx),
 			"gcp_storage_bucket":                  tableGcpStorageBucket(ctx),
 
-			// "gcp_compute_disk":                    tableGcpComputeDisk(ctx),
-			// "gcp_compute_route":                   tableGcpComputeRoute(ctx), https://github.com/turbot/steampipe/issues/108
+			/*
+				https://github.com/turbot/steampipe/issues/108
+				https://github.com/turbot/steampipe/issues/126
+
+				"gcp_compute_image":                   tableGcpComputeImage(ctx),
+				"gcp_compute_route":                   tableGcpComputeRoute(ctx),
+				"gcp_compute_vpn_tunnel":              tableGcpComputeVpnTunnel(ctx),
+			*/
+
 		},
 	}
 

--- a/gcp/plugin.go
+++ b/gcp/plugin.go
@@ -27,7 +27,6 @@ func Plugin(ctx context.Context) *plugin.Plugin {
 			"gcp_audit_policy":                    tableGcpAuditPolicy(ctx),
 			"gcp_cloudfunctions_function":         tableGcpCloudfunctionFunction(ctx),
 			"gcp_compute_address":                 tableGcpComputeAddress(ctx),
-			"gcp_compute_disk":                    tableGcpComputeDisk(ctx),
 			"gcp_compute_firewall":                tableGcpComputeFirewall(ctx),
 			"gcp_compute_forwarding_rule":         tableGcpComputeForwardingRule(ctx),
 			"gcp_compute_global_address":          tableGcpComputeGlobalAddress(ctx),
@@ -35,7 +34,6 @@ func Plugin(ctx context.Context) *plugin.Plugin {
 			"gcp_compute_image":                   tableGcpComputeImage(ctx),
 			"gcp_compute_instance":                tableGcpComputeInstance(ctx),
 			"gcp_compute_network":                 tableGcpComputeNetwork(ctx),
-			"gcp_compute_route":                   tableGcpComputeRoute(ctx),
 			"gcp_compute_router":                  tableGcpComputeRouter(ctx),
 			"gcp_compute_snapshot":                tableGcpComputeSnapshot(ctx),
 			"gcp_compute_vpn_tunnel":              tableGcpComputeVpnTunnel(ctx),
@@ -53,6 +51,9 @@ func Plugin(ctx context.Context) *plugin.Plugin {
 			"gcp_service_account":                 tableGcpServiceAccount(ctx),
 			"gcp_service_account_key":             tableGcpServiceAccountKey(ctx),
 			"gcp_storage_bucket":                  tableGcpStorageBucket(ctx),
+
+			// "gcp_compute_disk":                    tableGcpComputeDisk(ctx),
+			// "gcp_compute_route":                   tableGcpComputeRoute(ctx), https://github.com/turbot/steampipe/issues/108
 		},
 	}
 


### PR DESCRIPTION
## v0.0.5 [2021-02-24]

_What's new?_

- New tables added to plugin

  - gcp_compute_address ([#29](https://github.com/turbot/steampipe-plugin-gcp/issues/29))
  - gcp_compute_disk ([#47](https://github.com/turbot/steampipe-plugin-gcp/issues/47))
  - gcp_compute_firewall ([#42](https://github.com/turbot/steampipe-plugin-gcp/issues/42))
  - gcp_compute_forwarding_rule ([#53](https://github.com/turbot/steampipe-plugin-gcp/issues/53))
  - gcp_compute_network ([#43](https://github.com/turbot/steampipe-plugin-gcp/issues/43))
  - gcp_compute_router ([#51](https://github.com/turbot/steampipe-plugin-gcp/issues/51))
  - gcp_compute_snapshot ([#60](https://github.com/turbot/steampipe-plugin-gcp/issues/60))

_Enhancements_

- Added field `location` to resource tables that are not regional with value as `global`