### PR TITLE
Update SQL tables to remove the deprecated package. Closes #160

### DIFF
--- a/gcp/service.go
+++ b/gcp/service.go
@@ -18,7 +18,7 @@ import (
 	"google.golang.org/api/storage/v1"
 
 	computeBeta "google.golang.org/api/compute/v0.beta"
-	sql "google.golang.org/api/sql/v1beta4"
+	sqladmin "google.golang.org/api/sqladmin/v1beta4"
 )
 
 // BigQueryService returns the service connection for GCP BigQueryService service
@@ -85,18 +85,18 @@ func CloudResourceManagerService(ctx context.Context, d *plugin.QueryData) (*clo
 }
 
 // CloudSQLAdminService returns the service connection for GCP Cloud SQL Admin service
-func CloudSQLAdminService(ctx context.Context, d *plugin.QueryData) (*sql.Service, error) {
+func CloudSQLAdminService(ctx context.Context, d *plugin.QueryData) (*sqladmin.Service, error) {
 	// have we already created and cached the service?
 	serviceCacheKey := "CloudSQLAdminService"
 	if cachedData, ok := d.ConnectionManager.Cache.Get(serviceCacheKey); ok {
-		return cachedData.(*sql.Service), nil
+		return cachedData.(*sqladmin.Service), nil
 	}
 
 	// To get config arguments from plugin config file
 	setSessionConfig(d.Connection)
 
 	// so it was not in cache - create service
-	svc, err := sql.NewService(ctx)
+	svc, err := sqladmin.NewService(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/gcp/table_gcp_logging_sink.go
+++ b/gcp/table_gcp_logging_sink.go
@@ -52,7 +52,7 @@ func tableGcpLoggingSink(_ context.Context) *plugin.Table {
 			{
 				Name:        "create_time",
 				Description: "The creation timestamp of the sink",
-				Type:        proto.ColumnType_DATETIME,
+				Type:        proto.ColumnType_TIMESTAMP,
 				Transform:   transform.FromField("CreateTime").NullIfZero(),
 			},
 			{
@@ -69,7 +69,7 @@ func tableGcpLoggingSink(_ context.Context) *plugin.Table {
 			{
 				Name:        "update_time",
 				Description: "The last update timestamp of the sink",
-				Type:        proto.ColumnType_DATETIME,
+				Type:        proto.ColumnType_TIMESTAMP,
 				Transform:   transform.FromField("UpdateTime").NullIfZero(),
 			},
 			{

--- a/gcp/table_gcp_sql_backup.go
+++ b/gcp/table_gcp_sql_backup.go
@@ -8,7 +8,7 @@ import (
 	"github.com/turbot/steampipe-plugin-sdk/plugin"
 	"github.com/turbot/steampipe-plugin-sdk/plugin/transform"
 
-	sql "google.golang.org/api/sql/v1beta4"
+	sqladmin "google.golang.org/api/sqladmin/v1beta4"
 )
 
 //// TABLE DEFINITION
@@ -136,7 +136,7 @@ func listSQLBackups(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateD
 	plugin.Logger(ctx).Trace("listSQLBackups")
 
 	// Get the details of Cloud SQL instance
-	instance := h.Item.(*sql.DatabaseInstance)
+	instance := h.Item.(*sqladmin.DatabaseInstance)
 
 	// Create service connection
 	service, err := CloudSQLAdminService(ctx, d)
@@ -192,7 +192,7 @@ func getSQLBackup(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateDat
 }
 
 func getSQLBackupAka(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
-	backup := h.Item.(*sql.BackupRun)
+	backup := h.Item.(*sqladmin.BackupRun)
 
 	// Get project details
 	projectData, err := activeProject(ctx, d)

--- a/gcp/table_gcp_sql_database.go
+++ b/gcp/table_gcp_sql_database.go
@@ -8,11 +8,11 @@ import (
 	"github.com/turbot/steampipe-plugin-sdk/plugin"
 	"github.com/turbot/steampipe-plugin-sdk/plugin/transform"
 
-	sql "google.golang.org/api/sql/v1beta4"
+	sqladmin "google.golang.org/api/sqladmin/v1beta4"
 )
 
 type sqlDatabaseInfo = struct {
-	Database *sql.Database
+	Database *sqladmin.Database
 	Region   string
 }
 
@@ -117,7 +117,7 @@ func listSQLDatabases(ctx context.Context, d *plugin.QueryData, h *plugin.Hydrat
 	plugin.Logger(ctx).Trace("listSQLDatabases")
 
 	// Get the details of Cloud SQL instance
-	instance := h.Item.(*sql.DatabaseInstance)
+	instance := h.Item.(*sqladmin.DatabaseInstance)
 
 	// Create service connection
 	service, err := CloudSQLAdminService(ctx, d)

--- a/gcp/table_gcp_sql_database_instance.go
+++ b/gcp/table_gcp_sql_database_instance.go
@@ -8,7 +8,7 @@ import (
 	"github.com/turbot/steampipe-plugin-sdk/plugin/transform"
 
 	"google.golang.org/api/googleapi"
-	sql "google.golang.org/api/sql/v1beta4"
+	sqladmin "google.golang.org/api/sqladmin/v1beta4"
 )
 
 //// TABLE DEFINITION
@@ -382,7 +382,7 @@ func listSQLDatabaseInstances(ctx context.Context, d *plugin.QueryData, _ *plugi
 	project := projectData.Project
 
 	resp := service.Instances.List(project)
-	if err := resp.Pages(ctx, func(page *sql.InstancesListResponse) error {
+	if err := resp.Pages(ctx, func(page *sqladmin.InstancesListResponse) error {
 		for _, instance := range page.Items {
 			d.StreamListItem(ctx, instance)
 		}
@@ -435,7 +435,7 @@ func getSQLDatabaseInstanceUsers(ctx context.Context, d *plugin.QueryData, h *pl
 		return nil, err
 	}
 
-	instance := h.Item.(*sql.DatabaseInstance)
+	instance := h.Item.(*sqladmin.DatabaseInstance)
 	project := instance.Project
 
 	req, err := service.Users.List(project, instance.Name).Do()
@@ -452,7 +452,7 @@ func getSQLDatabaseInstanceUsers(ctx context.Context, d *plugin.QueryData, h *pl
 //// TRANSFORM FUNCTIONS
 
 func sqlDatabaseInstanceAka(_ context.Context, d *transform.TransformData) (interface{}, error) {
-	instance := d.HydrateItem.(*sql.DatabaseInstance)
+	instance := d.HydrateItem.(*sqladmin.DatabaseInstance)
 
 	akas := []string{"gcp://cloudsql.googleapis.com/projects/" + instance.Project + "/regions/" + instance.Region + "/instances/" + instance.Name}
 

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,6 @@ go 1.15
 
 require (
 	github.com/turbot/go-kit v0.1.1
-	github.com/turbot/steampipe-plugin-sdk v0.2.6
+	github.com/turbot/steampipe-plugin-sdk v0.2.7
 	google.golang.org/api v0.39.0
 )

--- a/go.sum
+++ b/go.sum
@@ -204,8 +204,8 @@ github.com/tkrajina/go-reflector v0.5.4 h1:dS9aJEa/eYNQU/fwsb5CSiATOxcNyA/gG/A7a
 github.com/tkrajina/go-reflector v0.5.4/go.mod h1:9PyLgEOzc78ey/JmQQHbW8cQJ1oucLlNQsg8yFvkVk8=
 github.com/turbot/go-kit v0.1.1 h1:JkLUyVp8m8jEj45C52dzh7Tj9jpxHP90y9+m8cpW1mo=
 github.com/turbot/go-kit v0.1.1/go.mod h1:hO/mY90fJXLWAJnAoDkYMvi3LVZ/r+z1tiz3E1uPSNA=
-github.com/turbot/steampipe-plugin-sdk v0.2.6 h1:dzIZJknmb+AQkC3eUF5ayKdyK4/JCMNK/37+t6cz2bg=
-github.com/turbot/steampipe-plugin-sdk v0.2.6/go.mod h1:3R868UGCRVR5ptSpYY+zGetiq2ZqjVDP8wlrapVh6rc=
+github.com/turbot/steampipe-plugin-sdk v0.2.7 h1:r353gMzFKFwO2MJHczDKChP8xtAMvzvpt9eUEX4zDKw=
+github.com/turbot/steampipe-plugin-sdk v0.2.7/go.mod h1:3R868UGCRVR5ptSpYY+zGetiq2ZqjVDP8wlrapVh6rc=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack/v4 v4.3.12/go.mod h1:gborTTJjAo/GWTqqRjrLCn9pgNN+NXzzngzBKDPIqw4=
 github.com/vmihailenco/tagparser v0.1.1/go.mod h1:OeAg3pn3UbLjkWt+rN9oFYB6u/cQgqMEUPoW2WPyhdI=


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging
customEnv TURBOT_TEST_EXPECTED_TIMEOUT 300

SETUP: tests/gcp_sql_database_instance []

PRETEST: tests/gcp_sql_database_instance

TEST: tests/gcp_sql_database_instance
Running terraform
data.google_client_config.current: Refreshing state...
data.null_data_source.resource: Refreshing state...
google_sql_database_instance.named_test_resource: Creating...
google_sql_database_instance.named_test_resource: Still creating... [10s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [20s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [30s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [40s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [50s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [1m0s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [1m10s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [1m20s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [1m30s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [1m40s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [1m50s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [2m0s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [2m10s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [2m20s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [2m30s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [2m40s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [2m50s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [3m0s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [3m10s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [3m20s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [3m30s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [3m40s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [3m50s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [4m0s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [4m10s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [4m20s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [4m30s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [4m40s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [4m50s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [5m0s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [5m10s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [5m20s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [5m30s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [5m40s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [5m50s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [6m0s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [6m10s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [6m20s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [6m30s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [6m40s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [6m50s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [7m0s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [7m10s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [7m20s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [7m30s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [7m40s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [7m50s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [8m0s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [8m10s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [8m20s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [8m30s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [8m40s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [8m50s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [9m0s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [9m10s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [9m20s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [9m30s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [9m40s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [9m50s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [10m0s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [10m10s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [10m20s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [10m30s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [10m40s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [10m50s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [11m0s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [11m10s elapsed]
google_sql_database_instance.named_test_resource: Creation complete after 11m11s [id=turbottest83725]
google_sql_user.users: Creating...
google_sql_user.users: Creation complete after 8s [id=turbottest83725/me.com/turbottest83725]

Warning: Deprecated Resource

The null_data_source was historically used to construct intermediate values to
re-use elsewhere in configuration, the same can now be achieved using locals


Apply complete! Resources: 2 added, 0 changed, 0 destroyed.

Outputs:

project_id = pikachu-aaa
resource_aka = gcp://cloudsql.googleapis.com/projects/pikachu-aaa/regions/us-east1/instances/turbottest83725
resource_name = turbottest83725
self_link = https://sqladmin.googleapis.com/sql/v1beta4/projects/pikachu-aaa/instances/turbottest83725

Running SQL query: test-get-query.sql
[
  {
    "connection_name": "pikachu-aaa:us-east1:turbottest83725",
    "crash_safe_replication_enabled": false,
    "data_disk_size_gb": 10,
    "data_disk_type": "PD_HDD",
    "database_version": "MYSQL_5_6",
    "enable_point_in_time_recovery": true,
    "instance_type": "CLOUD_SQL_INSTANCE",
    "kind": "sql#instance",
    "labels": {
      "name": "turbottest83725"
    },
    "location": "us-east1",
    "machine_type": "db-f1-micro",
    "name": "turbottest83725",
    "project": "pikachu-aaa",
    "self_link": "https://sqladmin.googleapis.com/sql/v1beta4/projects/pikachu-aaa/instances/turbottest83725",
    "storage_auto_resize": true
  }
]
✔ PASSED

Running SQL query: test-hydrate-query.sql
[
  {
    "host_name": "me.com",
    "name": "turbottest83725"
  }
]
✔ PASSED

Running SQL query: test-invalid-name-query.sql
null
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "database_version": "MYSQL_5_6",
    "name": "turbottest83725"
  }
]
✔ PASSED

Running SQL query: test-not-found-query.sql
null
✔ PASSED

Running SQL query: test-turbot-query.sql
[
  {
    "akas": [
      "gcp://cloudsql.googleapis.com/projects/pikachu-aaa/regions/us-east1/instances/turbottest83725"
    ],
    "tags": {
      "name": "turbottest83725"
    },
    "title": "turbottest83725"
  }
]
✔ PASSED

POSTTEST: tests/gcp_sql_database_instance

TEARDOWN: tests/gcp_sql_database_instance

SUMMARY:

1/1 passed.
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
N/A
```
</details>
