### PR TITLE
Fix browse tables link

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -39,7 +39,7 @@ from
 
 ## Documentation
 
-- **[Table definitions & examples →](gcp/tables)**
+- **[Table definitions & examples →](/plugins/gcp/tables)**
 
 ## Get started
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -39,7 +39,7 @@ from
 
 ## Documentation
 
-- **[Table definitions & examples →](/plugins/gcp/tables)**
+- **[Table definitions & examples →](/plugins/turbot/gcp/tables)**
 
 ## Get started
 


### PR DESCRIPTION
changed link in index.md to be qualified from the root of the website 

`gcp/tables` to `/plugins/turbot/gcp/tables`