### PR TITLE
[FIX] Not equals to operator not working as expected for the examples given in the table gcp_dns_managed_zone. Closes #162

### DIFF
--- a/docs/tables/gcp_dns_managed_zone.md
+++ b/docs/tables/gcp_dns_managed_zone.md
@@ -30,5 +30,9 @@ from
   gcp_dns_managed_zone
 where 
   visibility = 'public'
-  and dnssec_config_state <> 'on';
+  and 
+  (
+    dnssec_config_state is null
+    or dnssec_config_state = 'off'
+  );
 ```


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
N/A
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
### List public zones with DNSSEC disabled

```sql
select
  name,
  id,
  dns_name,
  dnssec_config_state,
  visibility
from
  gcp_dns_managed_zone
where 
  visibility = 'public'
  and 
  (
    dnssec_config_state is null
    or dnssec_config_state = 'off'
  );
```
```
+------------+---------------------+-------------+---------------------+------------+
| name       | id                  | dns_name    | dnssec_config_state | visibility |
+------------+---------------------+-------------+---------------------+------------+
| test-zone1 | ******************* | test12.com. | off                 | public     |
| test-zone2 | ******************* | test23.com. | <null>              | public     |
+------------+---------------------+-------------+---------------------+------------+
```
</details>
