### PR TITLE
In gcp_compute_disk table for disks encrypted with customer supplied encryption key field disk_encryption_kms_key does not have any information. How can one identify the type of encryption for disk. Closes #175

### DIFF
--- a/docs/tables/gcp_compute_disk.md
+++ b/docs/tables/gcp_compute_disk.md
@@ -26,11 +26,40 @@ select
   name,
   id,
   zone_name,
-  disk_encryption_kms_key
+  disk_encryption_kms_key_customer_supplied,
+  disk_encryption_kms_key_customer_managed
 from
   gcp_compute_disk
 where
-  disk_encryption_kms_key is null;
+  disk_encryption_kms_key_customer_supplied is null and disk_encryption_kms_key_customer_managed is null;
+```
+
+### List of disks with Customer-managed key
+
+```sql
+select
+  name,
+  id,
+  zone_name,
+  disk_encryption_kms_key_customer_managed
+from
+  gcp_compute_disk
+where
+  length(disk_encryption_kms_key_customer_managed) <> 0;
+```
+
+### List of disks with Customer-supplied key
+
+```sql
+select
+  name,
+  id,
+  zone_name,
+  disk_encryption_kms_key_customer_supplied
+from
+  gcp_compute_disk
+where
+  length(disk_encryption_kms_key_customer_supplied) <> 0;
 ```
 
 ### List of disks that are not in use

--- a/gcp/table_gcp_compute_disk.go
+++ b/gcp/table_gcp_compute_disk.go
@@ -55,10 +55,16 @@ func tableGcpComputeDisk(ctx context.Context) *plugin.Table {
 				Type:        proto.ColumnType_STRING,
 			},
 			{
-				Name:        "disk_encryption_kms_key",
-				Description: "The name of the encryption key that is used to encrypt storage data.",
+				Name:        "disk_encryption_kms_key_customer_managed",
+				Description: "The name of the customer managed encryption key that is used to encrypt storage data.",
 				Type:        proto.ColumnType_STRING,
 				Transform:   transform.FromField("DiskEncryptionKey.KmsKeyName"),
+			},
+			{
+				Name:        "disk_encryption_kms_key_customer_supplied",
+				Description: "The name of the customer supplied encryption key that is used to encrypt storage data.",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("DiskEncryptionKey.Sha256"),
 			},
 			{
 				Name:        "disk_encryption_kms_key_service_account",


### PR DESCRIPTION

# Integration test logs
<details>
  <summary>Logs</summary>
  
```
SETUP: tests/gcp_compute_disk []

PRETEST: tests/gcp_compute_disk

TEST: tests/gcp_compute_disk
Running terraform
data.google_client_config.current: Refreshing state...
data.google_iam_policy.admin: Refreshing state...
data.google_compute_image.my_image: Refreshing state...
data.null_data_source.resource: Refreshing state...
google_compute_resource_policy.policy: Creating...
google_compute_disk.named_test_resource: Creating...
google_compute_disk.named_test_resource: Creation complete after 3s [id=projects/parker-aaa/zones/us-central1-a/disks/turbottest98412]
google_compute_disk_iam_policy.policy: Creating...
google_compute_resource_policy.policy: Creation complete after 3s [id=projects/parker-aaa/regions/us-central1/resourcePolicies/my-resource-policy]
google_compute_disk_resource_policy_attachment.attachment: Creating...
google_compute_disk_iam_policy.policy: Creation complete after 2s [id=projects/parker-aaa/zones/us-central1-a/disks/turbottest98412]
google_compute_disk_resource_policy_attachment.attachment: Creation complete after 3s [id=parker-aaa/us-central1-a/turbottest98412/my-resource-policy]

Warning: Deprecated Resource

The null_data_source was historically used to construct intermediate values to
re-use elsewhere in configuration, the same can now be achieved using locals


Apply complete! Resources: 4 added, 0 changed, 0 destroyed.

Outputs:

etag = BwXA38a4WCM=
project = parker-aaa
resource_aka = gcp://compute.googleapis.com/projects/parker-aaa/zones/us-central1-a/disks/turbottest98412
resource_id = projects/parker-aaa/zones/us-central1-a/disks/turbottest98412
resource_name = turbottest98412
self_link = https://www.googleapis.com/compute/v1/projects/parker-aaa/zones/us-central1-a/disks/turbottest98412

Running SQL query: test-get-query.sql
[
  {
    "akas": [
      "gcp://compute.googleapis.com/projects/parker-aaa/zones/us-central1-a/disks/turbottest98412"
    ],
    "labels": {
      "name": "turbottest98412"
    },
    "location": "us-central1-a",
    "name": "turbottest98412",
    "project": "parker-aaa",
    "self_link": "https://www.googleapis.com/compute/v1/projects/parker-aaa/zones/us-central1-a/disks/turbottest98412",
    "tags": {
      "name": "turbottest98412"
    },
    "title": "turbottest98412"
  }
]
✔ PASSED

Running SQL query: test-hydrate-query.sql
[
  {
    "iam_policy": {
      "bindings": [
        {
          "members": [
            "user:lalit@turbot.com"
          ],
          "role": "roles/viewer"
        }
      ],
      "etag": "BwXA38a4WCM=",
      "version": 1
    },
    "name": "turbottest98412"
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "akas": [
      "gcp://compute.googleapis.com/projects/parker-aaa/zones/us-central1-a/disks/turbottest98412"
    ],
    "labels": {
      "name": "turbottest98412"
    },
    "location": "us-central1-a",
    "name": "turbottest98412",
    "project": "parker-aaa",
    "self_link": "https://www.googleapis.com/compute/v1/projects/parker-aaa/zones/us-central1-a/disks/turbottest98412",
    "tags": {
      "name": "turbottest98412"
    },
    "title": "turbottest98412"
  }
]
✔ PASSED

Running SQL query: test-notfound-query.sql
null
✔ PASSED

POSTTEST: tests/gcp_compute_disk

TEARDOWN: tests/gcp_compute_disk

SUMMARY:

1/1 passed.
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
 select
  name,
  id,
  zone_name,
  disk_encryption_kms_key_customer_supplied,
  disk_encryption_kms_key_customer_managed
from
  gcp_compute_disk
where
  disk_encryption_kms_key_customer_supplied is null and disk_encryption_kms_key_customer_managed is null;

+-----------------------+---------------------+---------------+-------------------------------------------+------------------------------------------+
| name                  | id                  | zone_name     | disk_encryption_kms_key_customer_supplied | disk_encryption_kms_key_customer_managed |
+-----------------------+---------------------+---------------+-------------------------------------------+------------------------------------------+
| google-managed-disk-1 | 8762648939698313000 | us-central1-a | <null>                                    | <null>                                   |
| google-managed-disk-2 | 3237317446338287000 | us-central1-a | <null>                                    | <null>                                   |
+-----------------------+---------------------+---------------+-------------------------------------------+------------------------------------------+

 select
  name,
  id,
  zone_name,
  disk_encryption_kms_key_customer_managed
from
  gcp_compute_disk
where
  length(disk_encryption_kms_key_customer_managed) <> 0;
  
  +-------------------------+---------------------+---------------+----------------------------------------------------------------------------------------------------------------------+
| name                    | id                  | zone_name     | disk_encryption_kms_key_customer_managed                                                                             |
+-------------------------+---------------------+---------------+----------------------------------------------------------------------------------------------------------------------+
| customer-managed-disk-1 | 6906545450836023000 | us-central1-a | projects/parker-aaa/locations/global/keyRings/turbottest9650-keyring/cryptoKeys/turbottest9650/cryptoKeyVersions/324 |
| customer-managed-disk-2 | 779421122988545800  | us-central1-a | projects/parker-aaa/locations/global/keyRings/turbottest9650-keyring/cryptoKeys/turbottest9650/cryptoKeyVersions/324 |
+-------------------------+---------------------+---------------+----------------------------------------------------------------------------------------------------------------------+

select
  name,
  id,
  zone_name,
  disk_encryption_kms_key_customer_supplied
from
  gcp_compute_disk
where
  length(disk_encryption_kms_key_customer_supplied) <> 0;
  
  +--------------------------+---------------------+---------------+----------------------------------------------+
| name                     | id                  | zone_name     | disk_encryption_kms_key_customer_supplied    |
+--------------------------+---------------------+---------------+----------------------------------------------+
| customer-supplied-disk-2 | 58742335322396290   | us-central1-a | MqlMXSBnTt+2N/05Azg8Fvvho28Dp58u+LFde5/TcfA= |
| customer-supplied-disk-1 | 3465707786911602700 | us-central1-a | MqlMXSBnTt+2N/05Azg8Fvvho28Dp58u+LFde5/TcfA= |
+--------------------------+---------------------+---------------+----------------------------------------------+
```
</details>
