### PR TITLE
In gcp_compute_disk table for disks encrypted with customer supplied encryption key field disk_encryption_kms_key does not have any information. How can one identify the type of encryption for disk. Closes #175

### DIFF
--- a/docs/tables/gcp_compute_disk.md
+++ b/docs/tables/gcp_compute_disk.md
@@ -19,7 +19,7 @@ from
   gcp_compute_disk;
 ```
 
-### List of disks with encryption key type
+### List of disks with Google-managed key
 
 ```sql
 select
@@ -28,7 +28,9 @@ select
   zone_name,
   disk_encryption_key_type
 from
-  gcp_compute_disk;
+  gcp_compute_disk
+where
+  disk_encryption_key_type = 'Google managed';
 ```
 
 ### List of disks that are not in use

--- a/docs/tables/gcp_compute_disk.md
+++ b/docs/tables/gcp_compute_disk.md
@@ -19,18 +19,16 @@ from
   gcp_compute_disk;
 ```
 
-### List of disks with Google-managed key
+### List of disks with encryption key
 
 ```sql
 select
   name,
   id,
   zone_name,
-  disk_encryption_kms_key
+  disk_encryption_key_type
 from
-  gcp_compute_disk
-where
-  disk_encryption_kms_key is null;
+  gcp_compute_disk;
 ```
 
 ### List of disks that are not in use

--- a/docs/tables/gcp_compute_disk.md
+++ b/docs/tables/gcp_compute_disk.md
@@ -19,7 +19,7 @@ from
   gcp_compute_disk;
 ```
 
-### List of disks with encryption key
+### List of disks with encryption key type
 
 ```sql
 select

--- a/docs/tables/gcp_compute_disk.md
+++ b/docs/tables/gcp_compute_disk.md
@@ -19,7 +19,7 @@ from
   gcp_compute_disk;
 ```
 
-### List of disks with Google-managed key
+### List disks encrypted with Google-managed key
 
 ```sql
 select
@@ -33,7 +33,7 @@ where
   disk_encryption_key_type = 'Google managed';
 ```
 
-### List of disks that are not in use
+### List disks that are not in use
 
 ```sql
 select
@@ -46,7 +46,7 @@ where
   users is null;
 ```
 
-### List of disks that are Regional
+### List regional disks
 
 ```sql
 select
@@ -58,7 +58,7 @@ where
   location_type = 'REGIONAL';
 ```
 
-### Disk count in each availability zone
+### Count the number of disks per availability zone
 
 ```sql
 select
@@ -72,7 +72,7 @@ order by
   count desc;
 ```
 
-### List Disks by size
+### List disks ordered by size
 
 ```sql
 select

--- a/gcp/table_gcp_compute_disk.go
+++ b/gcp/table_gcp_compute_disk.go
@@ -63,7 +63,7 @@ func tableGcpComputeDisk(ctx context.Context) *plugin.Table {
 				Name:        "disk_encryption_key_type",
 				Description: "The type of encryption key used to encrypt storage data. Valid values are Google managed | Customer managed | Customer supplied.",
 				Type:        proto.ColumnType_STRING,
-				Transform:   transform.From(getDiskEncryptionKey),
+				Transform:   transform.From(diskEncryptionKey),
 			},
 			{
 				Name:        "kind",
@@ -398,7 +398,7 @@ func diskLocation(_ context.Context, d *transform.TransformData) (interface{}, e
 	return locationData[param], nil
 }
 
-func getDiskEncryptionKey(_ context.Context, d *transform.TransformData) (interface{}, error) {
+func diskEncryptionKey(_ context.Context, d *transform.TransformData) (interface{}, error) {
 	i := d.HydrateItem.(*compute.Disk)
 
 	if i.DiskEncryptionKey == nil {

--- a/gcp/table_gcp_compute_disk.go
+++ b/gcp/table_gcp_compute_disk.go
@@ -55,16 +55,15 @@ func tableGcpComputeDisk(ctx context.Context) *plugin.Table {
 				Type:        proto.ColumnType_STRING,
 			},
 			{
-				Name:        "disk_encryption_kms_key",
-				Description: "The name of the encryption key that is used to encrypt storage data.",
-				Type:        proto.ColumnType_STRING,
-				Transform:   transform.FromField("DiskEncryptionKey.KmsKeyName"),
+				Name:        "disk_encryption_key",
+				Description: "The name of the encryption key that is used to encrypt stored data.",
+				Type:        proto.ColumnType_JSON,
 			},
 			{
-				Name:        "disk_encryption_kms_key_service_account",
-				Description: "The service account being used for the encryption request for the given KMS key. If absent, the Compute Engine default service account is used.",
+				Name:        "disk_encryption_key_type",
+				Description: "The type of encryption key used to encrypt storage data. Valid values are Google managed | Customer managed | Customer supplied.",
 				Type:        proto.ColumnType_STRING,
-				Transform:   transform.FromField("DiskEncryptionKey.KmsKeyServiceAccount"),
+				Transform:   transform.From(getDiskEncryptionKey),
 			},
 			{
 				Name:        "kind",
@@ -397,4 +396,17 @@ func diskLocation(_ context.Context, d *transform.TransformData) (interface{}, e
 	}
 
 	return locationData[param], nil
+}
+
+func getDiskEncryptionKey(_ context.Context, d *transform.TransformData) (interface{}, error) {
+	i := d.HydrateItem.(*compute.Disk)
+
+	if i.DiskEncryptionKey == nil {
+		return "Google managed", nil
+	} else if len(i.DiskEncryptionKey.KmsKeyName) > 0 {
+		return "Customer managed", nil
+	} else if len(i.DiskEncryptionKey.Sha256) > 0 {
+		return "Customer supplied", nil
+	}
+	return nil, nil
 }

--- a/gcp/table_gcp_compute_disk.go
+++ b/gcp/table_gcp_compute_disk.go
@@ -63,7 +63,7 @@ func tableGcpComputeDisk(ctx context.Context) *plugin.Table {
 				Name:        "disk_encryption_key_type",
 				Description: "The type of encryption key used to encrypt storage data. Valid values are Google managed | Customer managed | Customer supplied.",
 				Type:        proto.ColumnType_STRING,
-				Transform:   transform.From(diskEncryptionKey),
+				Transform:   transform.From(diskEncryptionKeyType),
 			},
 			{
 				Name:        "kind",
@@ -398,7 +398,7 @@ func diskLocation(_ context.Context, d *transform.TransformData) (interface{}, e
 	return locationData[param], nil
 }
 
-func diskEncryptionKey(_ context.Context, d *transform.TransformData) (interface{}, error) {
+func diskEncryptionKeyType(_ context.Context, d *transform.TransformData) (interface{}, error) {
 	i := d.HydrateItem.(*compute.Disk)
 
 	if i.DiskEncryptionKey == nil {

--- a/gcp/table_gcp_compute_disk.go
+++ b/gcp/table_gcp_compute_disk.go
@@ -56,7 +56,7 @@ func tableGcpComputeDisk(ctx context.Context) *plugin.Table {
 			},
 			{
 				Name:        "disk_encryption_key",
-				Description: "The name of the encryption key that is used to encrypt stored data.",
+				Description: "Specifies the encryption configuration used to encrypt stored data.",
 				Type:        proto.ColumnType_JSON,
 			},
 			{


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
SETUP: tests/gcp_compute_disk []

PRETEST: tests/gcp_compute_disk

TEST: tests/gcp_compute_disk
Running terraform
data.google_client_config.current: Refreshing state...
data.google_compute_image.my_image: Refreshing state...
data.google_iam_policy.admin: Refreshing state...
data.null_data_source.resource: Refreshing state...
google_compute_resource_policy.policy: Creating...
google_compute_disk.named_test_resource: Creating...
google_compute_disk.named_test_resource: Creation complete after 4s [id=projects/parker-aaa/zones/us-central1-a/disks/turbottest50724]
google_compute_resource_policy.policy: Creation complete after 4s [id=projects/parker-aaa/regions/us-central1/resourcePolicies/my-resource-policy]
google_compute_disk_resource_policy_attachment.attachment: Creating...
google_compute_disk_iam_policy.policy: Creating...
google_compute_disk_iam_policy.policy: Creation complete after 1s [id=projects/parker-aaa/zones/us-central1-a/disks/turbottest50724]
google_compute_disk_resource_policy_attachment.attachment: Creation complete after 3s [id=parker-aaa/us-central1-a/turbottest50724/my-resource-policy]

Warning: Deprecated Resource

The null_data_source was historically used to construct intermediate values to
re-use elsewhere in configuration, the same can now be achieved using locals


Apply complete! Resources: 4 added, 0 changed, 0 destroyed.

Outputs:

etag = BwXBapLc2z4=
project = parker-aaa
resource_aka = gcp://compute.googleapis.com/projects/parker-aaa/zones/us-central1-a/disks/turbottest50724
resource_id = projects/parker-aaa/zones/us-central1-a/disks/turbottest50724
resource_name = turbottest50724
self_link = https://www.googleapis.com/compute/v1/projects/parker-aaa/zones/us-central1-a/disks/turbottest50724

Running SQL query: test-get-query.sql
[
  {
    "akas": [
      "gcp://compute.googleapis.com/projects/parker-aaa/zones/us-central1-a/disks/turbottest50724"
    ],
    "labels": {
      "name": "turbottest50724"
    },
    "location": "us-central1-a",
    "name": "turbottest50724",
    "project": "parker-aaa",
    "self_link": "https://www.googleapis.com/compute/v1/projects/parker-aaa/zones/us-central1-a/disks/turbottest50724",
    "tags": {
      "name": "turbottest50724"
    },
    "title": "turbottest50724"
  }
]
✔ PASSED

Running SQL query: test-hydrate-query.sql
[
  {
    "iam_policy": {
      "bindings": [
        {
          "members": [
            "user:lalit@turbot.com"
          ],
          "role": "roles/viewer"
        }
      ],
      "etag": "BwXBapLc2z4=",
      "version": 1
    },
    "name": "turbottest50724"
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "akas": [
      "gcp://compute.googleapis.com/projects/parker-aaa/zones/us-central1-a/disks/turbottest50724"
    ],
    "labels": {
      "name": "turbottest50724"
    },
    "location": "us-central1-a",
    "name": "turbottest50724",
    "project": "parker-aaa",
    "self_link": "https://www.googleapis.com/compute/v1/projects/parker-aaa/zones/us-central1-a/disks/turbottest50724",
    "tags": {
      "name": "turbottest50724"
    },
    "title": "turbottest50724"
  }
]
✔ PASSED

Running SQL query: test-notfound-query.sql
null
✔ PASSED

POSTTEST: tests/gcp_compute_disk

TEARDOWN: tests/gcp_compute_disk

SUMMARY:

1/1 passed.
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
select
  name,
  id,
  zone_name,
  disk_encryption_key_type
from
  gcp_compute_disk
where
  disk_encryption_key_type = 'Google managed';

+----------------------+---------------------+---------------+--------------------------+
| name                 | id                  | zone_name     | disk_encryption_key_type |
+----------------------+---------------------+---------------+--------------------------+
| google-manageddisk-1 | 2226300935343003400 | us-central1-a | Google managed           |
+----------------------+---------------------+---------------+--------------------------+

```
</details>
