### PR TITLE
Add self_link for gcp_dns_managed_zone table. Closes #194

### DIFF
--- a/gcp/table_gcp_dns_managed_zone.go
+++ b/gcp/table_gcp_dns_managed_zone.go
@@ -251,7 +251,7 @@ func getDnsZoneSelfLink(ctx context.Context, d *plugin.QueryData, h *plugin.Hydr
 	}
 	project := projectData.Project
 
-	selfLink := "https://www.googleapis.com/dns/v1beta2/projects/" + project + "/managedZones/" + zone.Name
+	selfLink := "https://www.googleapis.com/dns/v1/projects/" + project + "/managedZones/" + zone.Name
 
 	return selfLink, nil
 }

--- a/gcp/table_gcp_dns_managed_zone.go
+++ b/gcp/table_gcp_dns_managed_zone.go
@@ -252,5 +252,6 @@ func getDnsZoneSelfLink(ctx context.Context, d *plugin.QueryData, h *plugin.Hydr
 	project := projectData.Project
 
 	selfLink := "https://www.googleapis.com/dns/v1beta2/projects/" + project + "/managedZones/" + zone.Name
+
 	return selfLink, nil
 }


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
SETUP: tests/gcp_dns_managed_zone []

PRETEST: tests/gcp_dns_managed_zone

TEST: tests/gcp_dns_managed_zone
Running terraform
google_compute_network.named_test_resource: Creating...
google_compute_network.named_test_resource: Still creating... [10s elapsed]
google_compute_network.named_test_resource: Still creating... [20s elapsed]
google_compute_network.named_test_resource: Creation complete after 24s [id=projects/pikachu-aaa/global/networks/turbottest46210]
google_dns_managed_zone.named_test_resource: Creating...
google_dns_managed_zone.named_test_resource: Creation complete after 1s [id=projects/pikachu-aaa/managedZones/turbottest46210]

Warning: Deprecated Resource

The null_data_source was historically used to construct intermediate values to
re-use elsewhere in configuration, the same can now be achieved using locals


Apply complete! Resources: 2 added, 0 changed, 0 destroyed.

Outputs:

network = "https://www.googleapis.com/compute/v1/projects/pikachu-aaa/global/networks/turbottest46210"
project_id = "pikachu-aaa"
resource_aka = "gcp://dns.googleapis.com/projects/pikachu-aaa/managedZones/turbottest46210"
resource_id = "projects/pikachu-aaa/managedZones/turbottest46210"
resource_name = "turbottest46210"

Running SQL query: test-get-query.sql
[
  {
    "description": "Test managed zone to validate the table outcome.",
    "dns_name": "turbot.com.",
    "kind": "dns#managedZone",
    "labels": {
      "name": "turbottest46210"
    },
    "location": "global",
    "name": "turbottest46210",
    "name_servers": [
      "ns-gcp-private.googledomains.com."
    ],
    "private_visibility_config_networks": [
      {
        "kind": "dns#managedZonePrivateVisibilityConfigNetwork",
        "networkUrl": "https://www.googleapis.com/compute/v1/projects/pikachu-aaa/global/networks/turbottest46210"
      }
    ],
    "project": "pikachu-aaa",
    "visibility": "private"
  }
]
✔ PASSED

Running SQL query: test-invalid-name-query.sql
null
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "description": "Test managed zone to validate the table outcome.",
    "name": "turbottest46210"
  }
]
✔ PASSED

Running SQL query: test-not-found-query.sql
null
✔ PASSED

Running SQL query: test-turbot-query.sql
[
  {
    "akas": [
      "gcp://dns.googleapis.com/projects/pikachu-aaa/managedZones/turbottest46210"
    ],
    "tags": {
      "name": "turbottest46210"
    },
    "title": "turbottest46210"
  }
]
✔ PASSED

POSTTEST: tests/gcp_dns_managed_zone

TEARDOWN: tests/gcp_dns_managed_zone

SUMMARY:

1/1 passed.


```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
> select
  name,
  id,
  dns_name,
  creation_time,
  visibility
from
  gcp_dns_managed_zone;
+------+---------------------+----------------+---------------------+------------+
| name | id                  | dns_name       | creation_time       | visibility |
+------+---------------------+----------------+---------------------+------------+
| test | 5786585914995123927 | sss@gmail.com. | 2021-05-10 07:11:50 | public     |
+------+---------------------+----------------+---------------------+------------+
```
</details>
