### PR TITLE
One of the example for gcp_compute_address table is incorrect. closes #217

### DIFF
--- a/docs/tables/gcp_compute_address.md
+++ b/docs/tables/gcp_compute_address.md
@@ -31,7 +31,7 @@ select
   creation_timestamp,
   status
 from
-  gcp_compute_address where status = 'IN_USE' ;
+  gcp_compute_address where status != 'IN_USE' ;
 ```
 
 ### Address count by each network_tier


### PR DESCRIPTION


# Integration test logs
<details>
  <summary>Logs</summary>
  
```
Add passing integration test logs here
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
Add example SQL query results here (please include the input queries as well)
```
</details>
