### PR TITLE
Type might be incorrect for column id in table gcp_compute_disk. closes #218

### DIFF
--- a/gcp/table_gcp_compute_disk.go
+++ b/gcp/table_gcp_compute_disk.go
@@ -32,7 +32,7 @@ func tableGcpComputeDisk(ctx context.Context) *plugin.Table {
 			{
 				Name:        "id",
 				Description: "The unique identifier for the resource. This identifier is defined by the server.",
-				Type:        proto.ColumnType_DOUBLE,
+				Type:        proto.ColumnType_INT,
 			},
 			{
 				Name:        "creation_timestamp",


### PR DESCRIPTION
Note: Id column column type was double so the extra Zeros were being added in the end of the value, so converted it to Int

# Integration test logs
<details>
  <summary>Logs</summary>
  
```
Add passing integration test logs here
```
</details>

# Example query results
<details>
  <summary>Results</summary>

## With column type Double
  
```sql
selece name, id from gcp_compute_disk;

```

```
+----------------+---------------------+
| name           | id                  |
+----------------+---------------------+
| raj-cis-test2  | 9032020956267478000 |
| raj-cis-test3  | 6514447256340713000 |
| raj-cis-test-3 | 404602883300363100  |
+----------------+---------------------+

```

## With column type Int


```sql
selece name, id from gcp_compute_disk;

```

```
+----------------+---------------------+
| name           | id                  |
+----------------+---------------------+
| raj-cis-test2  | 9032020956267478221 |
| raj-cis-test3  | 6514447256340713201 |
| raj-cis-test-3 | 404602883300363041  |
+----------------+---------------------+
```

</details>
