### PR TITLE
Fix `ERROR: rpc error: code = Unknown desc = googleapi: Error 400: Invalid request: Invalid request since instance is not running., invalid`. Closes #243

### DIFF
--- a/gcp/table_gcp_sql_database.go
+++ b/gcp/table_gcp_sql_database.go
@@ -118,6 +118,12 @@ func listSQLDatabases(ctx context.Context, d *plugin.QueryData, h *plugin.Hydrat
 
 	// Get the details of Cloud SQL instance
 	instance := h.Item.(*sqladmin.DatabaseInstance)
+	
+	// ERROR: rpc error: code = Unknown desc = googleapi: Error 400: Invalid request: Invalid request since instance is not running., invalid
+	// Return nil, if the instance not in running state
+	if instance.State != "RUNNABLE" {
+		return nil, nil
+	}
 
 	// Create service connection
 	service, err := CloudSQLAdminService(ctx, d)
@@ -163,6 +169,11 @@ func getSQLDatabase(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateD
 
 	name := d.KeyColumnQuals["name"].GetStringValue()
 	instanceName := d.KeyColumnQuals["instance_name"].GetStringValue()
+
+	// Return nil, if no input provided
+	if name == "" || instanceName == "" {
+		return nil, nil
+	}
 
 	// Get the region where the specified instance is created
 	instanceData, err := service.Instances.Get(project, instanceName).Do()


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging
customEnv TURBOT_TEST_EXPECTED_TIMEOUT 300

SETUP: tests/gcp_sql_database []

PRETEST: tests/gcp_sql_database

TEST: tests/gcp_sql_database
Running terraform
data.google_client_config.current: Refreshing state...
data.null_data_source.resource: Refreshing state...
google_sql_database_instance.named_test_resource: Creating...
google_sql_database_instance.named_test_resource: Still creating... [10s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [20s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [30s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [40s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [50s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [1m0s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [1m10s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [1m20s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [1m30s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [1m40s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [1m50s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [2m0s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [2m10s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [2m20s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [2m30s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [2m40s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [2m50s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [3m0s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [3m11s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [3m21s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [3m31s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [3m41s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [3m51s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [4m1s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [4m11s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [4m21s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [4m31s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [4m41s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [4m51s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [5m1s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [5m11s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [5m21s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [5m31s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [5m41s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [5m51s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [6m1s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [6m11s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [6m21s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [6m31s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [6m41s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [6m51s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [7m1s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [7m11s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [7m21s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [7m31s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [7m41s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [7m51s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [8m1s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [8m11s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [8m21s elapsed]
google_sql_database_instance.named_test_resource: Creation complete after 8m25s [id=turbottest31469]
google_sql_database.named_test_resource: Creating...
google_sql_database.named_test_resource: Creation complete after 7s [id=projects/project-abc/instances/turbottest31469/databases/turbottest31469]

Warning: Deprecated Resource

The null_data_source was historically used to construct intermediate values to
re-use elsewhere in configuration, the same can now be achieved using locals


Apply complete! Resources: 2 added, 0 changed, 0 destroyed.

Outputs:

project_id = project-abc
resource_aka = gcp://cloudsql.googleapis.com/projects/project-abc/instances/turbottest31469/databases/turbottest31469
resource_id = projects/project-abc/instances/turbottest31469/databases/turbottest31469
resource_name = turbottest31469
self_link = https://sqladmin.googleapis.com/sql/v1beta4/projects/project-abc/instances/turbottest31469/databases/turbottest31469

Running SQL query: test-get-query.sql
[
  {
    "charset": "utf8",
    "instance_name": "turbottest31469",
    "kind": "sql#database",
    "location": "us-east1",
    "name": "turbottest31469",
    "project": "project-abc",
    "self_link": "https://sqladmin.googleapis.com/sql/v1beta4/projects/project-abc/instances/turbottest31469/databases/turbottest31469"
  }
]
✔ PASSED

Running SQL query: test-hydrate-query.sql
[
  {
    "instance_name": "turbottest31469",
    "kind": "sql#database",
    "name": "turbottest31469"
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "instance_name": "turbottest31469",
    "name": "turbottest31469"
  }
]
✔ PASSED

Running SQL query: test-not-found-query.sql
null
✔ PASSED

Running SQL query: test-turbot-query.sql
[
  {
    "akas": [
      "gcp://cloudsql.googleapis.com/projects/project-abc/instances/turbottest31469/databases/turbottest31469"
    ],
    "title": "turbottest31469"
  }
]
✔ PASSED

POSTTEST: tests/gcp_sql_database

TEARDOWN: tests/gcp_sql_database

SUMMARY:

1/1 passed.
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
N/A
```
</details>
