### PR TITLE
Rename table `gcp_sql_database_instance_connections_daily` to `gcp_sql_database_instance_metric_connections_daily`. Closes #273

### DIFF
--- a/docs/tables/gcp_sql_database_instance_metric_connections_daily.md
+++ b/docs/tables/gcp_sql_database_instance_metric_connections_daily.md
@@ -1,6 +1,6 @@
-# Table: gcp_sql_database_instance_connections_daily
+# Table: gcp_sql_database_instance_metric_connections_daily
 
-GCP Monitoring metrics provide data about the performance of your systems. The `gcp_sql_database_instance_connections_daily` table provides metric statistics at 24 hour intervals for the past year.
+GCP Monitoring metrics provide data about the performance of your systems. The `gcp_sql_database_instance_metric_connections_daily` table provides metric statistics at 24 hour intervals for the past year.
 
 ## Examples
 
@@ -14,7 +14,7 @@ select
   average,
   sample_count
 from
-  gcp_sql_database_connections_daily
+  gcp_sql_database_instance_metric_connections_daily
 order by
   instance_id;
 ```
@@ -29,7 +29,7 @@ select
   round(average::numeric,2) as avg_connection,
   sample_count
 from
-  gcp_sql_database_connections_daily
+  gcp_sql_database_instance_metric_connections_daily
 where average > 100
 order by
   instance_id;
@@ -45,7 +45,7 @@ select
   round(average::numeric,2) as avg_connection,
   sample_count
 from
-  gcp_sql_database_connections_daily
+  gcp_sql_database_instance_metric_connections_daily
 where average < 10
 order by
   instance_id;

--- a/gcp/plugin.go
+++ b/gcp/plugin.go
@@ -91,7 +91,7 @@ func Plugin(ctx context.Context) *plugin.Plugin {
 			"gcp_sql_backup":                                          tableGcpSQLBackup(ctx),
 			"gcp_sql_database":                                        tableGcpSQLDatabase(ctx),
 			"gcp_sql_database_instance":                               tableGcpSQLDatabaseInstance(ctx),
-			"gcp_sql_database_instance_connections_daily":             tableGcpSQLDatabaseInstanceConnectionsMetricDaily(ctx),
+			"gcp_sql_database_instance_metric_connections_daily":      tableGcpSQLDatabaseInstanceConnectionsMetricDaily(ctx),
 			"gcp_sql_database_instance_metric_cpu_utilization":        tableGcpSQLDatabaseInstanceCpuUtilizationMetric(ctx),
 			"gcp_sql_database_instance_metric_cpu_utilization_daily":  tableGcpSQLDatabaseInstanceCpuUtilizationMetricDaily(ctx),
 			"gcp_sql_database_instance_metric_cpu_utilization_hourly": tableGcpSQLDatabaseInstanceCpuUtilizationMetricHourly(ctx),

--- a/gcp/table_gcp_sql_database_instance_metric_connections_daily.go
+++ b/gcp/table_gcp_sql_database_instance_metric_connections_daily.go
@@ -13,8 +13,8 @@ import (
 
 func tableGcpSQLDatabaseInstanceConnectionsMetricDaily(_ context.Context) *plugin.Table {
 	return &plugin.Table{
-		Name:        "gcp_sql_database_instance_connections_daily",
-		Description: "GCP SQL Database Instance Daily connections",
+		Name:        "gcp_sql_database_instance_metric_connections_daily",
+		Description: "GCP SQL Database Instance Metrics - Connections (Daily)",
 		List: &plugin.ListConfig{
 			ParentHydrate: listSQLDatabaseInstances,
 			Hydrate:       listSQLDatabaseInstanceMetricConnectionsDaily,
@@ -22,7 +22,7 @@ func tableGcpSQLDatabaseInstanceConnectionsMetricDaily(_ context.Context) *plugi
 		Columns: monitoringMetricColumns([]*plugin.Column{
 			{
 				Name:        "instance_id",
-				Description: "The SQL Instance name.",
+				Description: "The ID of the instance.",
 				Type:        proto.ColumnType_STRING,
 				Transform:   transform.FromField("DimensionValue"),
 			},


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
N/A
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
N/A
```
</details>

**_Renamed_**
- Table `gcp_sql_database_instance_connections_daily` -> `gcp_sql_database_instance_metric_connections_daily`
- Docs `gcp_sql_database_instance_metric_connections_daily`

**_Bug fixes_**
- Fix table name in example queries.
