### PR TITLE
Add labels column to gcp_kms_key and gcp_compute_instance_template table. Closes #299

### DIFF
--- a/gcp/table_gcp_compute_instance_template.go
+++ b/gcp/table_gcp_compute_instance_template.go
@@ -156,6 +156,12 @@ func tableGcpComputeInstanceTemplate(ctx context.Context) *plugin.Table {
 				Type:        proto.ColumnType_JSON,
 				Transform:   transform.FromField("Properties.Tags"),
 			},
+			{
+				Name:        "labels",
+				Description: "Labels associated with the instance template.",
+				Type:        proto.ColumnType_JSON,
+				Transform:   transform.FromField("Properties.Labels"),
+			},
 
 			// common resource columns
 			{

--- a/gcp/table_gcp_compute_instance_template.go
+++ b/gcp/table_gcp_compute_instance_template.go
@@ -158,7 +158,7 @@ func tableGcpComputeInstanceTemplate(ctx context.Context) *plugin.Table {
 			},
 			{
 				Name:        "labels",
-				Description: "Labels associated with the instance template.",
+				Description: "Labels to apply to instances that are created from these properties.",
 				Type:        proto.ColumnType_JSON,
 				Transform:   transform.FromField("Properties.Labels"),
 			},

--- a/gcp/table_gcp_kms_key.go
+++ b/gcp/table_gcp_kms_key.go
@@ -75,6 +75,11 @@ func tableGcpKmsKey(ctx context.Context) *plugin.Table {
 				Transform:   transform.FromValue(),
 			},
 			{
+				Name:        "labels",
+				Description: "Labels that apply to this kms key.",
+				Type:        proto.ColumnType_JSON,
+			},
+			{
 				Name:        "primary",
 				Description: "A copy of the primary CryptoKeyVersion that will be used by Encrypt when this CryptoKey is given in EncryptRequest.name.",
 				Type:        proto.ColumnType_JSON,

--- a/gcp/table_gcp_kms_key.go
+++ b/gcp/table_gcp_kms_key.go
@@ -76,7 +76,7 @@ func tableGcpKmsKey(ctx context.Context) *plugin.Table {
 			},
 			{
 				Name:        "labels",
-				Description: "Labels are key-value pair that helps to organize KMS keys.",
+				Description: "Labels are key-value pair that helps to organize KMS keys(https://cloud.google.com/kms/docs/labeling-keys).",
 				Type:        proto.ColumnType_JSON,
 			},
 			{

--- a/gcp/table_gcp_kms_key.go
+++ b/gcp/table_gcp_kms_key.go
@@ -76,7 +76,7 @@ func tableGcpKmsKey(ctx context.Context) *plugin.Table {
 			},
 			{
 				Name:        "labels",
-				Description: "Labels that apply to this kms key.",
+				Description: "Labels are key-value pair that helps to organize KMS keys.",
 				Type:        proto.ColumnType_JSON,
 			},
 			{

--- a/gcp/table_gcp_kms_key.go
+++ b/gcp/table_gcp_kms_key.go
@@ -76,7 +76,7 @@ func tableGcpKmsKey(ctx context.Context) *plugin.Table {
 			},
 			{
 				Name:        "labels",
-				Description: "Labels are key-value pair that helps to organize KMS keys(https://cloud.google.com/kms/docs/labeling-keys).",
+				Description: "Labels with user-defined metadata.",
 				Type:        proto.ColumnType_JSON,
 			},
 			{

--- a/gcp/table_gcp_kubernetes_node_pool.go
+++ b/gcp/table_gcp_kubernetes_node_pool.go
@@ -32,7 +32,7 @@ func tableGcpKubernetesNodePool(ctx context.Context) *plugin.Table {
 				Type:        proto.ColumnType_STRING,
 			},
 			{
-				Name:        "self_link",
+				Name:        "selfLink",
 				Description: "Server-defined URL for the resource.",
 				Type:        proto.ColumnType_STRING,
 			},

--- a/gcp/table_gcp_kubernetes_node_pool.go
+++ b/gcp/table_gcp_kubernetes_node_pool.go
@@ -32,7 +32,7 @@ func tableGcpKubernetesNodePool(ctx context.Context) *plugin.Table {
 				Type:        proto.ColumnType_STRING,
 			},
 			{
-				Name:        "selfLink",
+				Name:        "self_link",
 				Description: "Server-defined URL for the resource.",
 				Type:        proto.ColumnType_STRING,
 			},


### PR DESCRIPTION
# Example query results
<details>
  <summary>Results</summary>
  
```
> select resource_labels,tags from gcp_kubernetes_cluster
+-----------------------+-----------------------+
| resource_labels       | tags                  |
+-----------------------+-----------------------+
| {"test":"test-value"} | {"test":"test-value"} |
+-----------------------+-----------------------+

> select name,labels,tags from gcp_kms_key
+------------------------------------+-------------------------------------------------------------------------------------+--------------------------------------------------------------------------------
| name                               | labels                                                                              | tags                                                                           
+------------------------------------+-------------------------------------------------------------------------------------
| turbottest6138                     | {"name":"turbottest6138"}                                                           | {"name":"turbottest6138"}                                                      
| turbottest7719                     | {"name":"turbottest7719"}                                                           | {"name":"turbottest7719"}                                                      
| turbottest8223                     | {"name":"turbottest8223"}                                                           | {"name":"turbottest8223"}                                                      
| turbottest3642                     | {"name":"turbottest3642"}                                                           | {"name":"turbottest3642"}    

> select name,labels from gcp_compute_instance_template
+-------------------------------------+----------------------+
| name                                | labels               |
+-------------------------------------+----------------------+
| gke-cluster-1-default-pool-08d80842 | {"goog-gke-node":""} |
+-------------------------------------+----------------------+




```
</details>
