### PR TITLE
Fix selfLink column for gcp_kubernetes_node_pool table. Fixes #307

### DIFF
--- a/gcp/table_gcp_kubernetes_node_pool.go
+++ b/gcp/table_gcp_kubernetes_node_pool.go
@@ -32,7 +32,7 @@ func tableGcpKubernetesNodePool(ctx context.Context) *plugin.Table {
 				Type:        proto.ColumnType_STRING,
 			},
 			{
-				Name:        "selfLink",
+				Name:        "self_link",
 				Description: "Server-defined URL for the resource.",
 				Type:        proto.ColumnType_STRING,
 			},


### PR DESCRIPTION
# Example query results
<details>
  <summary>Results</summary>
  
```
> select name,self_link from gcp_kubernetes_node_pool
+--------------+-----------------------------------------------------------------------------------------------------------------------+
| name         | self_link                                                                                                             |
+--------------+-----------------------------------------------------------------------------------------------------------------------+
| default-pool | https://container.googleapis.com/v1/projects/parker-aaa/zones/us-central1-c/clusters/cluster-1/nodePools/default-pool |
+--------------+-----------------------------------------------------------------------------------------------------------------------+
```
</details>
