### PR TITLE
Update steampipe-plugin-sdk to 1.6.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,6 @@ go 1.15
 
 require (
 	github.com/turbot/go-kit v0.2.2-0.20210628165333-268ba0a30be3
-	github.com/turbot/steampipe-plugin-sdk v1.5.1
+	github.com/turbot/steampipe-plugin-sdk v1.6.1
 	google.golang.org/api v0.48.0
 )

--- a/go.sum
+++ b/go.sum
@@ -230,8 +230,8 @@ github.com/tkrajina/go-reflector v0.5.4 h1:dS9aJEa/eYNQU/fwsb5CSiATOxcNyA/gG/A7a
 github.com/tkrajina/go-reflector v0.5.4/go.mod h1:9PyLgEOzc78ey/JmQQHbW8cQJ1oucLlNQsg8yFvkVk8=
 github.com/turbot/go-kit v0.2.2-0.20210628165333-268ba0a30be3 h1:UAfWYp+K7oESlqomRus4k+h/dSPXU17tEcarbRdtBwQ=
 github.com/turbot/go-kit v0.2.2-0.20210628165333-268ba0a30be3/go.mod h1:SBdPRngbEfYubiR81iAVtO43oPkg1+ASr+XxvgbH7/k=
-github.com/turbot/steampipe-plugin-sdk v1.5.1 h1:xEYRbD0F2xlDLcL9vP6WgOr83x2lWvnxEmPXkahaacM=
-github.com/turbot/steampipe-plugin-sdk v1.5.1/go.mod h1:zM68yGM+wjkjDPz8yUTx6078GDTVWkrI26EC56XIspw=
+github.com/turbot/steampipe-plugin-sdk v1.6.1 h1:zXs0jiGyYc0vq3YwPDtw78jCZbirjSPEeTcZEDvoPJk=
+github.com/turbot/steampipe-plugin-sdk v1.6.1/go.mod h1:zM68yGM+wjkjDPz8yUTx6078GDTVWkrI26EC56XIspw=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack/v4 v4.3.12/go.mod h1:gborTTJjAo/GWTqqRjrLCn9pgNN+NXzzngzBKDPIqw4=
 github.com/vmihailenco/tagparser v0.1.1/go.mod h1:OeAg3pn3UbLjkWt+rN9oFYB6u/cQgqMEUPoW2WPyhdI=


### PR DESCRIPTION
# Example query results
<details>
  <summary>Results</summary>
  
```
> select * from gcp_compute_disk
+------------------------------------------+---------------------+---------------------+---------+--------+-------------+---------------------+--------------------------+--------------+-------------------
| name                                     | id                  | creation_timestamp  | size_gb | status | description | disk_encryption_key | disk_encryption_key_type | kind         | last_attach_timest
+------------------------------------------+---------------------+---------------------+---------+--------+-------------+---------------------+--------------------------+--------------+-------------------
| gke-cluster-1-default-pool-5e77f8e7-0b36 | 6784995084659335988 | 2021-09-21 08:54:51 | 100     | READY  |             | <null>              | Google managed           | compute#disk | 2021-09-21 08:54:5
| gke-cluster-1-default-pool-5e77f8e7-d38r | 1173739712526164788 | 2021-09-21 08:54:51 | 100     | READY  |             | <null>              | Google managed           | compute#disk | 2021-09-21 08:54:5
| gke-cluster-1-default-pool-5e77f8e7-8dzf | 508452417996858164  | 2021-09-21 08:54:52 | 100     | READY  |             | <null>              | Google managed           | compute#disk | 2021-09-21 08:54:5
+------------------------------------------+---------------------+---------------------+---------+--------+-------------+---------------------+--------------------------+--------------+-------------------
```
</details>
