### PR TITLE
Expand tilde in credential_file configuration

### DIFF
--- a/gcp/utils.go
+++ b/gcp/utils.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"runtime"
 	"strings"
 
@@ -150,7 +151,19 @@ func setSessionConfig(connection *plugin.Connection) []option.ClientOption {
 			os.Setenv("CLOUDSDK_CORE_PROJECT", *gcpConfig.Project)
 		}
 		if gcpConfig.CredentialFile != nil {
-			os.Setenv("GOOGLE_APPLICATION_CREDENTIALS", *gcpConfig.CredentialFile)
+			home, err := os.UserHomeDir()
+			if err != nil {
+				return nil
+			}
+			var path string
+			if *gcpConfig.CredentialFile == "~" {
+				path = home
+			} else if strings.HasPrefix(*gcpConfig.CredentialFile, "~/"){
+				path = filepath.Join(home, (*gcpConfig.CredentialFile)[2:])
+			} else {
+				path = *gcpConfig.CredentialFile
+			}
+			os.Setenv("GOOGLE_APPLICATION_CREDENTIALS", path)
 		}
 		if gcpConfig.ImpersonateServiceAccount != nil {
 			opts = append(opts, option.ImpersonateCredentials(*gcpConfig.ImpersonateServiceAccount))


### PR DESCRIPTION
Currently the example configuration at https://hub.steampipe.io/plugins/turbot/gcp uses tildes to represent the users home directory. This doesn't seem to be supported by the GCP SDK however, this PR expands the tilde to the current users home directory to support using the `credential_file` configuration this way.

Haven't run any tests on this branch yet, I'll need to look into how to do that.

# Integration test logs

TODO: Integration tests
<details>
  <summary>Logs</summary>
  
```
Add passing integration test logs here
```
</details>

