### PR TITLE
Update Steampipe plugin SDK to v1.6.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/turbot/steampipe-plugin-gcp
 go 1.15
 
 require (
-	github.com/turbot/go-kit v0.2.2-0.20210628165333-268ba0a30be3
-	github.com/turbot/steampipe-plugin-sdk v1.6.1
+	github.com/turbot/go-kit v0.3.0
+	github.com/turbot/steampipe-plugin-sdk v1.6.2
 	google.golang.org/api v0.48.0
 )

--- a/go.sum
+++ b/go.sum
@@ -228,10 +228,10 @@ github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/tkrajina/go-reflector v0.5.4 h1:dS9aJEa/eYNQU/fwsb5CSiATOxcNyA/gG/A7a582D5s=
 github.com/tkrajina/go-reflector v0.5.4/go.mod h1:9PyLgEOzc78ey/JmQQHbW8cQJ1oucLlNQsg8yFvkVk8=
-github.com/turbot/go-kit v0.2.2-0.20210628165333-268ba0a30be3 h1:UAfWYp+K7oESlqomRus4k+h/dSPXU17tEcarbRdtBwQ=
-github.com/turbot/go-kit v0.2.2-0.20210628165333-268ba0a30be3/go.mod h1:SBdPRngbEfYubiR81iAVtO43oPkg1+ASr+XxvgbH7/k=
-github.com/turbot/steampipe-plugin-sdk v1.6.1 h1:zXs0jiGyYc0vq3YwPDtw78jCZbirjSPEeTcZEDvoPJk=
-github.com/turbot/steampipe-plugin-sdk v1.6.1/go.mod h1:zM68yGM+wjkjDPz8yUTx6078GDTVWkrI26EC56XIspw=
+github.com/turbot/go-kit v0.3.0 h1:o4zZIO1ovdmJ2bHWOdXnnt8jJMIDGqYSkZvBREzFeMQ=
+github.com/turbot/go-kit v0.3.0/go.mod h1:SBdPRngbEfYubiR81iAVtO43oPkg1+ASr+XxvgbH7/k=
+github.com/turbot/steampipe-plugin-sdk v1.6.2 h1:CqugHzxr/5V7pysM2GnAXDzC0Zoal6fXo5j9FJix2gc=
+github.com/turbot/steampipe-plugin-sdk v1.6.2/go.mod h1:y7q8abyaXXQNzwE9l4Tn/gkEnvmcyPpyedpHF04wggs=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack/v4 v4.3.12/go.mod h1:gborTTJjAo/GWTqqRjrLCn9pgNN+NXzzngzBKDPIqw4=
 github.com/vmihailenco/tagparser v0.1.1/go.mod h1:OeAg3pn3UbLjkWt+rN9oFYB6u/cQgqMEUPoW2WPyhdI=


### PR DESCRIPTION
# Example query results
<details>
  <summary>Results</summary>
  
```
> select * from gcp_project
+------------+------------+--------------------------------------------------------------------+----------------+-----------------+---------------------+--------------------------------------+--------+---
| name       | project_id | self_link                                                          | project_number | lifecycle_state | create_time         | parent                               | labels | ti
+------------+------------+--------------------------------------------------------------------+----------------+-----------------+---------------------+--------------------------------------+--------+---
| parker-aaa | parker-aaa | https://cloudresourcemanager.googleapis.com/v1/projects/parker-aaa | 979620418102   | ACTIVE          | 2019-05-22 12:08:03 | {"id":"12258536632","type":"folder"} | <null> | pa
+------------+------------+--------------------------------------------------------------------+----------------+-----------------+---------------------+--------------------------------------+--------+---
> select * from gcp_compute_network
+-----------------------------+---------------------+---------------------+-------------------------+-----------------+--------------+------------+-----------------+------+--------------------------------
| name                        | id                  | creation_timestamp  | auto_create_subnetworks | description     | gateway_ipv4 | ipv4_range | kind            | mtu  | self_link                      
+-----------------------------+---------------------+---------------------+-------------------------+-----------------+--------------+------------+-----------------+------+--------------------------------
| test-net-with-no-dns-policy | 4577051564254690300 | 2021-05-20 11:19:35 | false                   |                 | <null>       | <null>     | compute#network | 1460 | https://www.googleapis.com/comp
| turbottest4251              | 2297009420028172300 | 2021-02-17 09:49:36 | true                    |                 | <null>       | <null>     | compute#network | 1460 | https://www.googleapis.com/comp
|                             |                     |                     |                         |                 |              |            |                 |      |                                
|                             |                     |                     |                         |                 |              |            |                 |      |                                
| raj-cis-test-nw             | 529512961903467200  | 2021-05-07 11:28:10 | false                   | raj-cis-test-nw | <null>       | <null>     | compute#network | 1460 | https://www.googleapis.com/comp
| turbottest93498             | 3666276188332636700 | 2021-05-21 09:57:25 | true                    |                 | <null>       | <null>     | compute#network | 1460 | https://www.googleapis.com/comp
|                             |                     |                     |                         |                 |              |            |                 |      |                                
|                             |                     |                     |                         |                 |              |            |                 |      |                                
|                             |                     |                     |                         |                 |              |            |                 |      |                                
+-----------------------------+---------------------+---------------------+-------------------------+-----------------+--------------+------------+-----------------+------+--------------------------------

```
</details>
