### PR TITLE
Add nil check in get call for gcp_compute_address table. closes #325

### DIFF
--- a/gcp/table_gcp_compute_address.go
+++ b/gcp/table_gcp_compute_address.go
@@ -61,6 +61,7 @@ func tableGcpComputeAddress(ctx context.Context) *plugin.Table {
 				Name:        "creation_timestamp",
 				Description: "The creation timestamp of the resource.",
 				Type:        proto.ColumnType_TIMESTAMP,
+				Transform:   transform.FromGo().NullIfZero(),
 			},
 			{
 				Name:        "kind",
@@ -214,6 +215,11 @@ func getComputeAddress(ctx context.Context, d *plugin.QueryData, h *plugin.Hydra
 func addressSelfLinkToTurbotData(_ context.Context, d *transform.TransformData) (interface{}, error) {
 	address := d.HydrateItem.(*compute.Address)
 	param := d.Param.(string)
+
+	// Empty check
+	if len(address.SelfLink) == 0 {
+		return nil, nil
+	}
 
 	region := getLastPathElement(types.SafeString(address.Region))
 	project := strings.Split(address.SelfLink, "/")[6]

--- a/gcp/table_gcp_compute_address.go
+++ b/gcp/table_gcp_compute_address.go
@@ -191,6 +191,11 @@ func getComputeAddress(ctx context.Context, d *plugin.QueryData, h *plugin.Hydra
 
 	var address compute.Address
 	name := d.KeyColumnQuals["name"].GetStringValue()
+	
+	// Empty check
+	if name == "" {
+		return nil, nil
+	}
 
 	resp := service.Addresses.AggregatedList(project).Filter("name=" + name)
 	if err := resp.Pages(
@@ -215,11 +220,6 @@ func getComputeAddress(ctx context.Context, d *plugin.QueryData, h *plugin.Hydra
 func addressSelfLinkToTurbotData(_ context.Context, d *transform.TransformData) (interface{}, error) {
 	address := d.HydrateItem.(*compute.Address)
 	param := d.Param.(string)
-
-	// Empty check
-	if len(address.SelfLink) == 0 {
-		return nil, nil
-	}
 
 	region := getLastPathElement(types.SafeString(address.Region))
 	project := strings.Split(address.SelfLink, "/")[6]


### PR DESCRIPTION

# Integration test logs
<details>
  <summary>Logs</summary>
  
```
No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging
customEnv TURBOT_TEST_EXPECTED_TIMEOUT undefined

SETUP: tests/gcp_compute_global_address []

PRETEST: tests/gcp_compute_global_address

TEST: tests/gcp_compute_global_address
Running terraform
data.google_client_config.current: Refreshing state...
data.null_data_source.resource: Refreshing state...
google_compute_network.network: Creating...
google_compute_network.network: Still creating... [10s elapsed]
google_compute_network.network: Creation complete after 12s [id=projects/parker-aaa/global/networks/turbottest81233]
google_compute_global_address.named_test_resource: Creating...
google_compute_global_address.named_test_resource: Still creating... [10s elapsed]
google_compute_global_address.named_test_resource: Creation complete after 12s [id=projects/parker-aaa/global/addresses/turbottest81233]

Warning: Deprecated Resource

The null_data_source was historically used to construct intermediate values to
re-use elsewhere in configuration, the same can now be achieved using locals


Apply complete! Resources: 2 added, 0 changed, 0 destroyed.

Outputs:

project_id = parker-aaa
resource_aka = gcp://compute.googleapis.com/projects/parker-aaa/global/addresses/turbottest81233
resource_id = projects/parker-aaa/global/addresses/turbottest81233
resource_name = turbottest81233
self_link = https://www.googleapis.com/compute/v1/projects/parker-aaa/global/addresses/turbottest81233

Running SQL query: test-get-query.sql
[
  {
    "address_type": "INTERNAL",
    "description": "Test global address to validate integration test.",
    "kind": "compute#address",
    "name": "turbottest81233",
    "network_tier": "PREMIUM",
    "project": "parker-aaa",
    "self_link": "https://www.googleapis.com/compute/v1/projects/parker-aaa/global/addresses/turbottest81233"
  }
]
✔ PASSED

Running SQL query: test-hydrate-query.sql
[
  {
    "address_type": "INTERNAL",
    "description": "Test global address to validate integration test.",
    "kind": "compute#address",
    "name": "turbottest81233",
    "network_tier": "PREMIUM",
    "self_link": "https://www.googleapis.com/compute/v1/projects/parker-aaa/global/addresses/turbottest81233"
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "description": "Test global address to validate integration test.",
    "name": "turbottest81233"
  }
]
✔ PASSED

Running SQL query: test-not-found-query.sql
null
✔ PASSED

Running SQL query: test-turbot-query.sql
[
  {
    "akas": [
      "gcp://compute.googleapis.com/projects/parker-aaa/global/addresses/turbottest81233"
    ],
    "title": "turbottest81233"
  }
]
✔ PASSED

POSTTEST: tests/gcp_compute_global_address

TEARDOWN: tests/gcp_compute_global_address

SUMMARY:

1/1 passed.

```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
select * from gcp_compute_global_address where name = ''
+------+----+---------+--------------+------------+-------------+--------------------+------+---------+--------------+---------------+---------+-----------+--------+------------+-------+-------+------+----------+---------+
| name | id | address | address_type | ip_version | description | creation_timestamp | kind | network | network_tier | prefix_length | purpose | self_link | status | subnetwork | users | title | akas | location | project |
+------+----+---------+--------------+------------+-------------+--------------------+------+---------+--------------+---------------+---------+-----------+--------+------------+-------+-------+------+----------+---------+
+------+----+---------+--------------+------------+-------------+--------------------+------+---------+--------------+---------------+---------+-----------+--------+------------+-------+-------+------+----------+---------+

```
</details>
