### PR TITLE
Add nil check in get call for gcp_bigquery_table table. closes #324

### DIFF
--- a/gcp/table_gcp_bigquery_table.go
+++ b/gcp/table_gcp_bigquery_table.go
@@ -314,8 +314,13 @@ func getBigqueryTable(ctx context.Context, d *plugin.QueryData, h *plugin.Hydrat
 
 //// TRANSFORM FUNCTIONS
 
-func bigqueryTableAkas(ctx context.Context, h *transform.TransformData) (interface{}, error) {
+func bigqueryTableAkas(_ context.Context, h *transform.TransformData) (interface{}, error) {
 	data := tableID(h.HydrateItem)
+	
+	// Empty check
+	if len(data) == 0 {
+		return nil, nil
+	}
 
 	projectID := strings.Split(data, ":")[0]
 	id := strings.Split(data, ":")[1]
@@ -326,9 +331,14 @@ func bigqueryTableAkas(ctx context.Context, h *transform.TransformData) (interfa
 	return akas, nil
 }
 
-func bigQueryTableTitle(ctx context.Context, h *transform.TransformData) (interface{}, error) {
+func bigQueryTableTitle(_ context.Context, h *transform.TransformData) (interface{}, error) {
 	data := tableID(h.HydrateItem)
 	name := tableName(h.HydrateItem)
+
+	// Empty check
+	if len(name) == 0 {
+		return nil, nil
+	}
 
 	if len(name) > 0 {
 		return name, nil

--- a/gcp/table_gcp_bigquery_table.go
+++ b/gcp/table_gcp_bigquery_table.go
@@ -304,6 +304,11 @@ func getBigqueryTable(ctx context.Context, d *plugin.QueryData, h *plugin.Hydrat
 		datasetID = d.KeyColumnQuals["dataset_id"].GetStringValue()
 		id = d.KeyColumnQuals["table_id"].GetStringValue()
 	}
+	
+	// Empty Check
+	if id == "" {
+		return nil, nil
+	}
 
 	resp, err := service.Tables.Get(project, datasetID, id).Do()
 	if err != nil {
@@ -316,11 +321,6 @@ func getBigqueryTable(ctx context.Context, d *plugin.QueryData, h *plugin.Hydrat
 
 func bigqueryTableAkas(_ context.Context, h *transform.TransformData) (interface{}, error) {
 	data := tableID(h.HydrateItem)
-	
-	// Empty check
-	if len(data) == 0 {
-		return nil, nil
-	}
 
 	projectID := strings.Split(data, ":")[0]
 	id := strings.Split(data, ":")[1]
@@ -334,11 +334,6 @@ func bigqueryTableAkas(_ context.Context, h *transform.TransformData) (interface
 func bigQueryTableTitle(_ context.Context, h *transform.TransformData) (interface{}, error) {
 	data := tableID(h.HydrateItem)
 	name := tableName(h.HydrateItem)
-
-	// Empty check
-	if len(name) == 0 {
-		return nil, nil
-	}
 
 	if len(name) > 0 {
 		return name, nil

--- a/gcp/table_gcp_bigquery_table.go
+++ b/gcp/table_gcp_bigquery_table.go
@@ -306,7 +306,7 @@ func getBigqueryTable(ctx context.Context, d *plugin.QueryData, h *plugin.Hydrat
 	}
 	
 	// Empty Check
-	if id == "" {
+	if id == "" || datasetID == ""{
 		return nil, nil
 	}
 


### PR DESCRIPTION


# Integration test logs
<details>
  <summary>Logs</summary>
  
```
No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging
customEnv TURBOT_TEST_EXPECTED_TIMEOUT undefined

SETUP: tests/gcp_bigquery_table []

PRETEST: tests/gcp_bigquery_table

TEST: tests/gcp_bigquery_table
Running terraform
data.google_client_config.current: Refreshing state...
data.null_data_source.resource: Refreshing state...
google_service_account.named_test_resource: Creating...
google_bigquery_dataset.named_test_resource: Creating...
google_bigquery_dataset.named_test_resource: Creation complete after 2s [id=projects/parker-aaa/datasets/turbottest31568]
google_bigquery_table.named_test_resource: Creating...
google_service_account.named_test_resource: Creation complete after 3s [id=projects/parker-aaa/serviceAccounts/turbottest31568@parker-aaa.iam.gserviceaccount.com]
google_bigquery_table.named_test_resource: Creation complete after 1s [id=projects/parker-aaa/datasets/turbottest31568/tables/turbottest31568]

Warning: Deprecated Resource

The null_data_source was historically used to construct intermediate values to
re-use elsewhere in configuration, the same can now be achieved using locals


Apply complete! Resources: 3 added, 0 changed, 0 destroyed.

Outputs:

etag = R01ADcxL8dWegKe9vVLKPw==
project_id = parker-aaa
region_id = us-east1
resource_aka = gcp://bigquery.googleapis.com/projects/parker-aaa/datasets/turbottest31568/tables/turbottest31568
resource_id = projects/parker-aaa/datasets/turbottest31568/tables/turbottest31568
resource_name = turbottest31568
self_link = https://bigquery.googleapis.com/bigquery/v2/projects/parker-aaa/datasets/turbottest31568/tables/turbottest31568
service_account_email = turbottest31568@parker-aaa.iam.gserviceaccount.com

Running SQL query: test-get-query.sql
[
  {
    "dataset_id": "turbottest31568",
    "id": "parker-aaa:turbottest31568.turbottest31568",
    "kind": "bigquery#table",
    "labels": {
      "name": "turbottest31568"
    },
    "location": "us-east1",
    "project": "parker-aaa",
    "range_partitioning": null,
    "self_link": "https://bigquery.googleapis.com/bigquery/v2/projects/parker-aaa/datasets/turbottest31568/tables/turbottest31568",
    "table_id": "turbottest31568",
    "time_partitioning": {
      "type": "DAY"
    },
    "title": "turbottest31568",
    "type": "TABLE"
  }
]
✔ PASSED

Running SQL query: test-invalid-name-query.sql
null
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "dataset_id": "turbottest31568",
    "table_id": "turbottest31568"
  }
]
✔ PASSED

Running SQL query: test-not-found-query.sql
null
✔ PASSED

Running SQL query: test-turbot-query.sql
[
  {
    "akas": [
      "gcp://bigquery.googleapis.com/projects/parker-aaa/datasets/turbottest31568/tables/turbottest31568"
    ],
    "tags": {
      "name": "turbottest31568"
    },
    "title": "turbottest31568"
  }
]
✔ PASSED

POSTTEST: tests/gcp_bigquery_table

TEARDOWN: tests/gcp_bigquery_table

SUMMARY:

1/1 passed.


```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
select * from gcp_bigquery_table where dataset_id = '' and table_id = ''
+------+----------+------------+----+------+-----------+---------------+-------------+------+-----------------+------+--------------+--------------------+-----------+---------------------+--------------------+----------+--------------------------+---------------+-------
| name | table_id | dataset_id | id | type | self_link | creation_time | description | etag | expiration_time | kind | kms_key_name | last_modified_time | num_bytes | num_long_term_bytes | num_physical_bytes | num_rows | require_partition_filter | snapshot_time | view_q
+------+----------+------------+----+------+-----------+---------------+-------------+------+-----------------+------+--------------+--------------------+-----------+---------------------+--------------------+----------+--------------------------+---------------+-------
+------+----------+------------+----+------+-----------+---------------+-------------+------+-----------------+------+--------------+--------------------+-----------+---------------------+--------------------+----------+--------------------------+---------------+-------
```
</details>
