### PR TITLE
Add nil check in get call for gcp_bigquery_dataset table. closes #323

### DIFF
--- a/gcp/table_gcp_bigquery_dataset.go
+++ b/gcp/table_gcp_bigquery_dataset.go
@@ -216,6 +216,10 @@ func getBigQueryDataset(ctx context.Context, d *plugin.QueryData, h *plugin.Hydr
 
 func bigQueryDatasetAka(ctx context.Context, h *transform.TransformData) (interface{}, error) {
 	data := datasetID(h.HydrateItem)
+	if len(data) == 0 {
+		return nil, nil
+	} 
+	
 	projectID := strings.Split(data, ":")[0]
 	id := strings.Split(data, ":")[1]
 
@@ -227,6 +231,10 @@ func bigQueryDatasetAka(ctx context.Context, h *transform.TransformData) (interf
 func bigQueryDatasetTitle(ctx context.Context, h *transform.TransformData) (interface{}, error) {
 	data := datasetID(h.HydrateItem)
 	name := datasetName(h.HydrateItem)
+
+	if len(name) == 0 {
+		return nil, nil
+	}
 
 	if len(name) > 0 {
 		return name, nil

--- a/gcp/table_gcp_bigquery_dataset.go
+++ b/gcp/table_gcp_bigquery_dataset.go
@@ -204,6 +204,7 @@ func getBigQueryDataset(ctx context.Context, d *plugin.QueryData, h *plugin.Hydr
 		id = d.KeyColumnQuals["dataset_id"].GetStringValue()
 	}
 	
+	// check if id is empty
 	if id == "" {
 		return nil, nil
 	}

--- a/gcp/table_gcp_bigquery_dataset.go
+++ b/gcp/table_gcp_bigquery_dataset.go
@@ -203,6 +203,10 @@ func getBigQueryDataset(ctx context.Context, d *plugin.QueryData, h *plugin.Hydr
 	} else {
 		id = d.KeyColumnQuals["dataset_id"].GetStringValue()
 	}
+	
+	if id == "" {
+		return nil, nil
+	}
 
 	resp, err := service.Datasets.Get(project, id).Do()
 	if err != nil {
@@ -216,9 +220,6 @@ func getBigQueryDataset(ctx context.Context, d *plugin.QueryData, h *plugin.Hydr
 
 func bigQueryDatasetAka(ctx context.Context, h *transform.TransformData) (interface{}, error) {
 	data := datasetID(h.HydrateItem)
-	if len(data) == 0 {
-		return nil, nil
-	} 
 	
 	projectID := strings.Split(data, ":")[0]
 	id := strings.Split(data, ":")[1]
@@ -231,10 +232,6 @@ func bigQueryDatasetAka(ctx context.Context, h *transform.TransformData) (interf
 func bigQueryDatasetTitle(ctx context.Context, h *transform.TransformData) (interface{}, error) {
 	data := datasetID(h.HydrateItem)
 	name := datasetName(h.HydrateItem)
-
-	if len(name) == 0 {
-		return nil, nil
-	}
 
 	if len(name) > 0 {
 		return name, nil


### PR DESCRIPTION

# Integration test logs
<details>
  <summary>Logs</summary>
  
```
No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging
customEnv TURBOT_TEST_EXPECTED_TIMEOUT undefined

SETUP: tests/gcp_bigquery_dataset []

PRETEST: tests/gcp_bigquery_dataset

TEST: tests/gcp_bigquery_dataset
Running terraform
data.google_client_config.current: Refreshing state...
data.null_data_source.resource: Refreshing state...
google_service_account.named_test_resource: Creating...
google_service_account.named_test_resource: Creation complete after 4s [id=projects/parker-aaa/serviceAccounts/turbottest6628@parker-aaa.iam.gserviceaccount.com]
google_bigquery_dataset.named_test_resource: Creating...
google_bigquery_dataset.named_test_resource: Creation complete after 3s [id=projects/parker-aaa/datasets/turbottest6628]

Warning: Deprecated Resource

The null_data_source was historically used to construct intermediate values to
re-use elsewhere in configuration, the same can now be achieved using locals


Apply complete! Resources: 2 added, 0 changed, 0 destroyed.

Outputs:

etag = mEaJijh0vY5e24Qmd7reWA==
project_id = parker-aaa
region_id = us-east1
resource_aka = gcp://bigquery.googleapis.com/projects/parker-aaa/datasets/turbottest6628
resource_id = projects/parker-aaa/datasets/turbottest6628
resource_name = turbottest6628
self_link = https://bigquery.googleapis.com/bigquery/v2/projects/parker-aaa/datasets/turbottest6628
service_account_email = turbottest6628@parker-aaa.iam.gserviceaccount.com

Running SQL query: test-get-query.sql
[
  {
    "access": [
      {
        "role": "OWNER",
        "userByEmail": "turbottest6628@parker-aaa.iam.gserviceaccount.com"
      },
      {
        "domain": "hashicorp.com",
        "role": "READER"
      }
    ],
    "dataset_id": "turbottest6628",
    "default_partition_expiration_ms": 0,
    "default_table_expiration_ms": 3600000,
    "description": "This is a test dataset to validate the table outcome.",
    "etag": "mEaJijh0vY5e24Qmd7reWA==",
    "id": "parker-aaa:turbottest6628",
    "kind": "bigquery#dataset",
    "labels": {
      "name": "turbottest6628"
    },
    "location": "us-east1",
    "name": "turbot_turbottest6628",
    "project": "parker-aaa",
    "self_link": "https://bigquery.googleapis.com/bigquery/v2/projects/parker-aaa/datasets/turbottest6628"
  }
]
✔ PASSED

Running SQL query: test-hydrate-query.sql
[
  {
    "dataset_id": "turbottest6628",
    "description": "This is a test dataset to validate the table outcome.",
    "etag": "mEaJijh0vY5e24Qmd7reWA==",
    "kind": "bigquery#dataset",
    "self_link": "https://bigquery.googleapis.com/bigquery/v2/projects/parker-aaa/datasets/turbottest6628"
  }
]
✔ PASSED

Running SQL query: test-invalid-name-query.sql
null
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "description": "This is a test dataset to validate the table outcome.",
    "name": "turbot_turbottest6628"
  }
]
✔ PASSED

Running SQL query: test-not-found-query.sql
null
✔ PASSED

Running SQL query: test-turbot-query.sql
[
  {
    "akas": [
      "gcp://bigquery.googleapis.com/projects/parker-aaa/datasets/turbottest6628"
    ],
    "tags": {
      "name": "turbottest6628"
    },
    "title": "turbot_turbottest6628"
  }
]
✔ PASSED

POSTTEST: tests/gcp_bigquery_dataset

TEARDOWN: tests/gcp_bigquery_dataset

SUMMARY:

1/1 passed.
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
select * from gcp_bigquery_dataset where dataset_id = ''
+------+------------+----+------+---------------+-------------+------+---------------------------------+-----------------------------+--------------+--------------------+-----------+--------+--------+-------+------+------+----------+---------+
| name | dataset_id | id | kind | creation_time | description | etag | default_partition_expiration_ms | default_table_expiration_ms | kms_key_name | last_modified_time | self_link | access | labels | title | tags | akas | location | project |
+------+------------+----+------+---------------+-------------+------+---------------------------------+-----------------------------+--------------+--------------------+-----------+--------+--------+-------+------+------+----------+---------+
+------+------------+----+------+---------------+-------------+------+---------------------------------+-----------------------------+--------------+--------------------+-----------+--------+--------+-------+------+------+----------+---------+
```
</details>
