### PR TITLE
Add column autopilot_enabled in gcp_kubernetes_cluster  table. Closes #343

### DIFF
--- a/gcp/table_gcp_kubernetes_cluster.go
+++ b/gcp/table_gcp_kubernetes_cluster.go
@@ -48,7 +48,7 @@ func tableGcpKubernetesCluster(ctx context.Context) *plugin.Table {
 			},
 			{
 				Name:        "autopilot_enabled",
-				Description: "Autopilot configuration for the cluster.",
+				Description: "Denotes whether autopilot configuration is enabled for the cluster.",
 				Type:        proto.ColumnType_BOOL,
 				Transform:   transform.FromField("Autopilot.Enabled"),
 			},

--- a/gcp/table_gcp_kubernetes_cluster.go
+++ b/gcp/table_gcp_kubernetes_cluster.go
@@ -47,6 +47,12 @@ func tableGcpKubernetesCluster(ctx context.Context) *plugin.Table {
 				Type:        proto.ColumnType_STRING,
 			},
 			{
+				Name:        "autopilot_enabled",
+				Description: "Autopilot configuration for the cluster.",
+				Type:        proto.ColumnType_BOOL,
+				Transform:   transform.FromField("Autopilot.Enabled"),
+			},
+			{
 				Name:        "description",
 				Description: "An optional description of this cluster.",
 				Type:        proto.ColumnType_STRING,
@@ -200,11 +206,6 @@ func tableGcpKubernetesCluster(ctx context.Context) *plugin.Table {
 			{
 				Name:        "autoscaling",
 				Description: "Cluster-level autoscaling configuration.",
-				Type:        proto.ColumnType_JSON,
-			},
-			{
-				Name:        "autopilot",
-				Description: "Autopilot configuration for the cluster.",
 				Type:        proto.ColumnType_JSON,
 			},
 			{

--- a/gcp/table_gcp_kubernetes_cluster.go
+++ b/gcp/table_gcp_kubernetes_cluster.go
@@ -203,6 +203,11 @@ func tableGcpKubernetesCluster(ctx context.Context) *plugin.Table {
 				Type:        proto.ColumnType_JSON,
 			},
 			{
+				Name:        "autopilot",
+				Description: "Autopilot configuration for the cluster.",
+				Type:        proto.ColumnType_JSON,
+			},
+			{
 				Name:        "conditions",
 				Description: "Which conditions caused the current cluster state.",
 				Type:        proto.ColumnType_JSON,


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
Running SQL query: test-get-query.sql
[
  {
    "akas": [
      "gcp://container.googleapis.com/v1/projects/parker-aaa/locations/us-east1/clusters/turbottest66483"
    ],
    "location": "us-east1",
    "name": "turbottest66483",
    "project": "parker-aaa",
    "services_ipv4_cidr": "10.99.240.0/20"
  }
]
✔ PASSED

Running SQL query: test-invalid-name-query.sql
null
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "akas": [
      "gcp://container.googleapis.com/v1/projects/parker-aaa/locations/us-east1/clusters/turbottest66483"
    ],
    "location": "us-east1",
    "name": "turbottest66483",
    "services_ipv4_cidr": "10.99.240.0/20"
  }
]
✔ PASSED

Running SQL query: test-not-found-query.sql
null
✔ PASSED

Running SQL query: test-turbot-query.sql
[
  {
    "akas": [
      "gcp://container.googleapis.com/v1/projects/parker-aaa/locations/us-east1/clusters/turbottest66483"
    ],
    "title": "turbottest66483"
  }
]
✔ PASSED

POSTTEST: tests/gcp_kubernetes_cluster

TEARDOWN: tests/gcp_kubernetes_cluster

SUMMARY:

1/1 passed.

```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
> select name, autopilot_enabled from gcp_kubernetes_cluster
+---------------------+-------------------+
| name                | autopilot_enabled |
+---------------------+-------------------+
| autopilot-cluster-1 | true              |
+---------------------+-------------------+

```
</details>
