### PR TITLE
Update the dependencies of gcp_kms_key_version table to use steampipe-plugin-sdk v2.1.1

### DIFF
--- a/docs/tables/gcp_kms_key_version.md
+++ b/docs/tables/gcp_kms_key_version.md
@@ -49,18 +49,19 @@ where
 order by
   create_time;
 ```
+
 ### List disabled keys
 
 ```sql
-select 
+select
   name,
-  max(crypto_key_version) crypto_key_version, 
-  state 
-from 
-  gcp_kms_key_version 
-where 
-  state like 'DISABLED' 
-group by 
+  max(crypto_key_version) crypto_key_version,
+  state
+from
+  gcp_kms_key_version
+where
+  state like 'DISABLED'
+group by
   name,
   state;
 ```

--- a/gcp/table_gcp_kms_key_version.go
+++ b/gcp/table_gcp_kms_key_version.go
@@ -7,9 +7,9 @@ import (
 	"sync"
 
 	"github.com/turbot/go-kit/types"
-	"github.com/turbot/steampipe-plugin-sdk/grpc/proto"
-	"github.com/turbot/steampipe-plugin-sdk/plugin"
-	"github.com/turbot/steampipe-plugin-sdk/plugin/transform"
+	"github.com/turbot/steampipe-plugin-sdk/v2/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v2/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v2/plugin/transform"
 	"google.golang.org/api/cloudkms/v1"
 )
 


### PR DESCRIPTION


# Integration test logs
<details>
  <summary>Logs</summary>
  
```
Add passing integration test logs here
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
select
  name,
  create_time,
  crypto_key_version,
  algorithm
from
  gcp_kms_key_version
where
  algorithm like 'GOOGLE_SYMMETRIC_ENCRYPTION'
order by
  create_time;
+------------------------------------+---------------------------+--------------------+-----------------------------+
| name                               | create_time               | crypto_key_version | algorithm                   |
+------------------------------------+---------------------------+--------------------+-----------------------------+
| rupkey-test-01                     | 2019-06-13T13:11:37+05:30 | 1                  | GOOGLE_SYMMETRIC_ENCRYPTION |
| test-key-sayan-cis                 | 2019-06-17T13:23:07+05:30 | 1                  | GOOGLE_SYMMETRIC_ENCRYPTION |
| test-key-sayan-cis                 | 2019-06-18T00:00:00+05:30 | 2                  | GOOGLE_SYMMETRIC_ENCRYPTION |
| rupkey-test-01                     | 2019-09-11T00:00:00+05:30 | 2                  | GOOGLE_SYMMETRIC_ENCRYPTION |
| terraform-key                      | 2019-10-23T15:43:40+05:30 | 1                  | GOOGLE_SYMMETRIC_ENCRYPTION |
| rupkey-test-01                     | 2019-12-10T00:00:00+05:30 | 3                  | GOOGLE_SYMMETRIC_ENCRYPTION |
| turbot-test-20191216-create-update | 2020-01-14T17:15:11+05:30 | 1                  | GOOGLE_SYMMETRIC_ENCRYPTION |
| terraform-key                      | 2020-01-21T00:00:00+05:30 | 2                  | GOOGLE_SYMMETRIC_ENCRYPTION |
| test1                              | 2020-02-13T18:28:05+05:30 | 1                  | GOOGLE_SYMMETRIC_ENCRYPTION |
| test1                              | 2020-02-14T22:14:44+05:30 | 2                  | GOOGLE_SYMMETRIC_ENCRYPTION |
| test1                              | 2020-02-16T02:01:24+05:30 | 3                  | GOOGLE_SYMMETRIC_ENCRYPTION |
```
</details>
