### PR TITLE
Fix list call for table gcp_compute_resource_policy closes #348

### DIFF
--- a/gcp/table_gcp_compute_resource_policy.go
+++ b/gcp/table_gcp_compute_resource_policy.go
@@ -20,7 +20,6 @@ func tableGcpComputeResourcePolicy(ctx context.Context) *plugin.Table {
 		Description: "GCP Compute Resource Policy",
 		Get: &plugin.GetConfig{
 			KeyColumns: plugin.SingleColumn("name"),
-			// ShouldIgnoreError: isIgnorableError([]string{"403", "503"}),
 			Hydrate:    getComputeResourcePolicy,
 		},
 		List: &plugin.ListConfig{


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging
customEnv TURBOT_TEST_EXPECTED_TIMEOUT undefined

SETUP: tests/gcp_compute_resource_policy []

PRETEST: tests/gcp_compute_resource_policy

TEST: tests/gcp_compute_resource_policy
Running terraform
data.google_client_config.current: Refreshing state...
data.null_data_source.resource: Refreshing state...
google_compute_resource_policy.named_test_resource: Creating...
google_compute_resource_policy.named_test_resource: Creation complete after 3s [id=projects/parker-aaa/regions/us-east1/resourcePolicies/turbottest86857]

Warning: Deprecated Resource

  on variables.tf line 33, in data "null_data_source" "resource":
  33: data "null_data_source" "resource" {

The null_data_source was historically used to construct intermediate values to
re-use elsewhere in configuration, the same can now be achieved using locals


Apply complete! Resources: 1 added, 0 changed, 0 destroyed.

Outputs:

project_id = parker-aaa
resource_aka = gcp://compute.googleapis.com/projects/parker-aaa/regions/us-east1/resourcePolicies/turbottest86857
resource_name = turbottest86857
self_link = https://www.googleapis.com/compute/v1/projects/parker-aaa/regions/us-east1/resourcePolicies/turbottest86857

Running SQL query: test-get-query.sql
[
  {
    "description": "Start and stop instances",
    "instance_schedule_policy": {
      "timeZone": "US/Central",
      "vmStartSchedule": {
        "schedule": "0 * * * *"
      },
      "vmStopSchedule": {
        "schedule": "15 * * * *"
      }
    },
    "kind": "compute#resourcePolicy",
    "name": "turbottest86857",
    "self_link": "https://www.googleapis.com/compute/v1/projects/parker-aaa/regions/us-east1/resourcePolicies/turbottest86857",
    "status": "READY"
  }
]
✔ PASSED

Running SQL query: test-invalid-name-query.sql
null
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "description": "Start and stop instances",
    "name": "turbottest86857"
  }
]
✔ PASSED

Running SQL query: test-not-found-query.sql
null
✔ PASSED

Running SQL query: test-turbot-query.sql
[
  {
    "akas": [
      "gcp://compute.googleapis.com/projects/parker-aaa/regions/us-east1/resourcePolicies/turbottest86857"
    ],
    "title": "turbottest86857"
  }
]
✔ PASSED

POSTTEST: tests/gcp_compute_resource_policy

TEARDOWN: tests/gcp_compute_resource_policy

SUMMARY:

1/1 passed.
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
> select name, status, location from gcp_compute_resource_policy;
+--------------------+--------+-------------+
| name               | status | location    |
+--------------------+--------+-------------+
| turbottest96258    | READY  | us-east1    |
| default-schedule-1 | READY  | us-central1 |
| schedule-1         | READY  | us-east1    |
+--------------------+--------+-------------+
```

```
> select name, status, location from gcp_compute_resource_policy where status = 'READY'
+--------------------+--------+-------------+
| name               | status | location    |
+--------------------+--------+-------------+
| turbottest96258    | READY  | us-east1    |
| schedule-1         | READY  | us-east1    |
| default-schedule-1 | READY  | us-central1 |
+--------------------+--------+-------------+
```
</details>
