### PR TITLE
Add column access_approval to table gcp_project closes #378

### DIFF
--- a/docs/tables/gcp_project.md
+++ b/docs/tables/gcp_project.md
@@ -16,3 +16,13 @@ select
 from
   gcp_project;
 ```
+
+### Get approval setting details
+
+```sql
+select
+  name,
+  jsonb_pretty(access_approval_settings) as access_approval_settings
+from
+  gcp_project;
+```

--- a/docs/tables/gcp_project.md
+++ b/docs/tables/gcp_project.md
@@ -17,7 +17,7 @@ from
   gcp_project;
 ```
 
-### Get approval setting details
+### Get access approval settings for all projects
 
 ```sql
 select

--- a/gcp/service.go
+++ b/gcp/service.go
@@ -24,10 +24,10 @@ import (
 	sqladmin "google.golang.org/api/sqladmin/v1beta4"
 )
 
-// AccessApprovalService returns the service connection for GCP Project AccessApprovalService service
+// AccessApprovalService returns the service connection for GCP Project AccessApproval service
 func AccessApprovalService(ctx context.Context, d *plugin.QueryData) (*accessapproval.Service, error) {
 	// have we already created and cached the service?
-	serviceCacheKey := "BigQueryService"
+	serviceCacheKey := "AccessApprovalService"
 	if cachedData, ok := d.ConnectionManager.Cache.Get(serviceCacheKey); ok {
 		return cachedData.(*accessapproval.Service), nil
 	}

--- a/gcp/service.go
+++ b/gcp/service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/turbot/steampipe-plugin-sdk/v3/plugin"
+	"google.golang.org/api/accessapproval/v1"
 	"google.golang.org/api/bigquery/v2"
 	"google.golang.org/api/bigtableadmin/v2"
 	"google.golang.org/api/cloudfunctions/v1"
@@ -22,6 +23,27 @@ import (
 	computeBeta "google.golang.org/api/compute/v0.beta"
 	sqladmin "google.golang.org/api/sqladmin/v1beta4"
 )
+
+// AccessApprovalService returns the service connection for GCP Project AccessApprovalService service
+func AccessApprovalService(ctx context.Context, d *plugin.QueryData) (*accessapproval.Service, error) {
+	// have we already created and cached the service?
+	serviceCacheKey := "BigQueryService"
+	if cachedData, ok := d.ConnectionManager.Cache.Get(serviceCacheKey); ok {
+		return cachedData.(*accessapproval.Service), nil
+	}
+
+	// To get config arguments from plugin config file
+	opts := setSessionConfig(d.Connection)
+
+	// so it was not in cache - create service
+	svc, err := accessapproval.NewService(ctx, opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	d.ConnectionManager.Cache.Set(serviceCacheKey, svc)
+	return svc, nil
+}
 
 // BigQueryService returns the service connection for GCP BigQueryService service
 func BigQueryService(ctx context.Context, d *plugin.QueryData) (*bigquery.Service, error) {

--- a/gcp/table_gcp_project.go
+++ b/gcp/table_gcp_project.go
@@ -62,7 +62,7 @@ func tableGcpProject(_ context.Context) *plugin.Table {
 				Type:        proto.ColumnType_JSON,
 			},
 			{
-				Name:        "access_approval",
+				Name:        "access_approvals",
 				Description: "Gets the settings associated with a project.",
 				Type:        proto.ColumnType_JSON,
 			},

--- a/gcp/table_gcp_project.go
+++ b/gcp/table_gcp_project.go
@@ -64,7 +64,7 @@ func tableGcpProject(_ context.Context) *plugin.Table {
 			},
 			{
 				Name:        "access_approval_settings",
-				Description: "Gets the settings associated with a project.",
+				Description: "The access approval settings associated with this project.",
 				Type:        proto.ColumnType_JSON,
 				Hydrate:     getProjectAccessApprovalSettings,
 				Transform:   transform.FromValue(),

--- a/gcp/table_gcp_project.go
+++ b/gcp/table_gcp_project.go
@@ -65,6 +65,8 @@ func tableGcpProject(_ context.Context) *plugin.Table {
 				Name:        "access_approvals",
 				Description: "Gets the settings associated with a project.",
 				Type:        proto.ColumnType_JSON,
+				Hydrate:     getProjectAccessapproval,
+				Transform:   transform.FromValue(),
 			},
 
 			// Steampipe standard columns

--- a/gcp/table_gcp_project.go
+++ b/gcp/table_gcp_project.go
@@ -63,7 +63,7 @@ func tableGcpProject(_ context.Context) *plugin.Table {
 				Type:        proto.ColumnType_JSON,
 			},
 			{
-				Name:        "access_approvals",
+				Name:        "access_approval",
 				Description: "Gets the settings associated with a project.",
 				Type:        proto.ColumnType_JSON,
 				Hydrate:     getProjectAccessapproval,

--- a/gcp/table_gcp_project.go
+++ b/gcp/table_gcp_project.go
@@ -63,10 +63,10 @@ func tableGcpProject(_ context.Context) *plugin.Table {
 				Type:        proto.ColumnType_JSON,
 			},
 			{
-				Name:        "access_approval",
+				Name:        "access_approval_settings",
 				Description: "Gets the settings associated with a project.",
 				Type:        proto.ColumnType_JSON,
-				Hydrate:     getProjectAccessapproval,
+				Hydrate:     getProjectAccessApprovalSettings,
 				Transform:   transform.FromValue(),
 			},
 
@@ -138,13 +138,13 @@ func getProjectAka(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateDa
 	return akas, nil
 }
 
-func getProjectAccessapproval(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
-	plugin.Logger(ctx).Trace("getProjectAccessapproval")
+func getProjectAccessApprovalSettings(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+	plugin.Logger(ctx).Trace("getProjectAccessApprovalSettings")
 
 	// Create Service Connection
 	service, err := AccessApprovalService(ctx, d)
 	if err != nil {
-		plugin.Logger(ctx).Error("gcp_project.getProjectAccessapproval", "connection_error", err)
+		plugin.Logger(ctx).Error("gcp_project.getProjectAccessApprovalSettings", "connection_error", err)
 		return nil, err
 	}
 
@@ -161,7 +161,7 @@ func getProjectAccessapproval(ctx context.Context, d *plugin.QueryData, h *plugi
 		if strings.Contains(err.Error(), "404") {
 			return nil, nil
 		}
-		plugin.Logger(ctx).Error("gcp_project.getProjectAccessapproval", "api_err", err)
+		plugin.Logger(ctx).Error("gcp_project.getProjectAccessApprovalSettings", "api_err", err)
 		return nil, err
 	}
 	return resp, nil

--- a/gcp/table_gcp_project.go
+++ b/gcp/table_gcp_project.go
@@ -2,6 +2,7 @@ package gcp
 
 import (
 	"context"
+	"strings"
 
 	"github.com/turbot/steampipe-plugin-sdk/v3/grpc/proto"
 	"github.com/turbot/steampipe-plugin-sdk/v3/plugin"
@@ -155,8 +156,11 @@ func getProjectAccessapproval(ctx context.Context, d *plugin.QueryData, h *plugi
 	}
 	project := projectId.(string)
 
-	resp, err := service.Projects.GetAccessApprovalSettings(project).Do()
+	resp, err := service.Projects.GetAccessApprovalSettings("projects/" + project + "/accessApprovalSettings").Do()
 	if err != nil {
+		if strings.Contains(err.Error(), "404") {
+			return nil, nil
+		}
 		plugin.Logger(ctx).Error("gcp_project.getProjectAccessapproval", "api_err", err)
 		return nil, err
 	}


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
N/A
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
> select name, access_approvals from gcp_project
+------------+------------------+
| name       | access_approval  |
+------------+------------------+
| abcdef-aaa | <null>           |
+------------+------------------+

> select name, access_approval from gcp_project
+------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------
| name       | access_approval                                                                                                                                                   
+------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------
| parker-aaa | {"enrolledServices":[{"cloudProduct":"all","enrollmentLevel":"BLOCK_ALL"}],"name":"projects/parker-aaa/accessApprovalSettings","notificationEmails":["abcd@gmail.c
+------------+---------------------------------------------------------------------------------------------------------------------------------------
```
</details>
