### PR TITLE
Add self_link column to gcp_dataproc_cluster table

### DIFF
--- a/gcp/table_gcp_dataproc_cluster.go
+++ b/gcp/table_gcp_dataproc_cluster.go
@@ -74,6 +74,12 @@ func tableGcpDataprocCluster(ctx context.Context) *plugin.Table {
 				Description: "The previous cluster status.",
 				Type:        proto.ColumnType_JSON,
 			},
+			{
+				Name:        "self_link",
+				Description: "Server-defined URL for the resource.",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.From(dataprocClusterSelfLink),
+			},
 
 			// Steampipe standard columns
 			{
@@ -242,4 +248,19 @@ func gcpDataprocClusterTurbotData(ctx context.Context, d *transform.TransformDat
 	}
 
 	return turbotData[param], nil
+}
+
+func dataprocClusterSelfLink(ctx context.Context, d *transform.TransformData) (interface{}, error) {
+	data := d.HydrateItem.(*dataproc.Cluster)
+
+	var location string
+	matrixLocation := plugin.GetMatrixItem(ctx)[matrixKeyLocation]
+	// Since, when the service API is disabled, matrixLocation value will be nil
+	if matrixLocation != nil {
+		location = matrixLocation.(*compute.Region).Name
+	}
+
+	selfLink := "https://dataproc.googleapis.com/v1/projects/" + data.ProjectId + "/regions/" + location + "/clusters/" + data.ClusterName
+
+	return selfLink, nil
 }


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
Add passing integration test logs here
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
select cluster_name, self_link from gcp_dataproc_cluster
+--------------+--------------------------------------------------------------------------------------------------+
| cluster_name | self_link                                                                                        |
+--------------+--------------------------------------------------------------------------------------------------+
| cluster-c73b | https://dataproc.googleapis.com/v1/projects/test-aaa/regions/us-central1/clusters/cluster-1234 |
+--------------+--------------------------------------------------------------------------------------------------
```
</details>
