### PR TITLE
Update gcp.spc

### DIFF
--- a/config/gcp.spc
+++ b/config/gcp.spc
@@ -7,7 +7,7 @@ connection "gcp" {
   #   - The standard gcloud SDK `CLOUDSDK_CORE_PROJECT` environment variable, if set; otherwise
   #   - The `GCP_PROJECT` environment variable, if set (this is deprecated); otherwise
   #   - The current active project project, as returned by the `gcloud config get-value project` command
-  #project = "YOUR_PROJECT_NAME"
+  #project = "YOUR_PROJECT_ID"
 
   # `credentials` (optional) - Either the path to a JSON credential file that contains Google application credentials,
   # or the contents of a service account key file in JSON format. If `credentials` is not specified in a connection,

--- a/docs/index.md
+++ b/docs/index.md
@@ -74,7 +74,7 @@ connection "gcp" {
   #   - The standard gcloud SDK `CLOUDSDK_CORE_PROJECT` environment variable, if set; otherwise
   #   - The `GCP_PROJECT` environment variable, if set (this is deprecated); otherwise
   #   - The current active project project, as returned by the `gcloud config get-value project` command
-  #project = "YOUR_PROJECT_NAME"
+  #project = "YOUR_PROJECT_ID"
 
   # `credentials` (optional) - Either the path to a JSON credential file that contains Google application credentials,
   # or the contents of a service account key file in JSON format. If `credentials` is not specified in a connection,


### PR DESCRIPTION
"`Project Name`" doesn't work in GCP we have to provide "`Project ID`", so changing the instruction accordingly as query fails with "`Project Name`" in the credential config file.

# Failure logs
<details>
  <summary>Logs</summary>

```
Warning: executeQueries: query 1 of 1 failed: ERROR: rpc error: code = Unknown desc = googleapi: Error 403: You don't have permission to list roles in projects/k8s-cluster., forbidden (SQLSTATE HV000) </summary>
```

</details>


# Integration test logs
<details>
  <summary>Logs</summary>
  
```
~$ steampipe query "select
  name,
  role_id,
  deleted,
  description,
  title
from
  gcp_iam_role;"
+-------------------------------------------------------------------+-------------------------------------------------------------+---------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+--------------------------------------------------------+
| name                                                              | role_id                                                     | deleted | description                                                                                                                                                                                                                                                                                                                                                | title                                                  |
+-------------------------------------------------------------------+-------------------------------------------------------------+---------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+--------------------------------------------------------+
| roles/anthossupport.serviceAgent                                  | anthossupport.serviceAgent                                  | false   |  Gives the Anthos Support Service Agent access to Cloud Platform resource.                                                                                                                                                                                                                                                                                 | Anthos Support Service Agent                           |
| roles/accessapproval.approver                                     | accessapproval.approver                                     | false   | Ability to view or act on access approval requests and view configuration                                                                                                                                                                                                                                                                                  
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
test_user~$ steampipe query "select
  name,
  role_id,
  deleted,
  description,
  title
from
  gcp_iam_role;"
Warning: executeQueries: query 1 of 1 failed: ERROR: rpc error: code = Unknown desc = googleapi: Error 403: You don't have permission to list roles in projects/k8s-cluster., forbidden (SQLSTATE HV000)
```
</details>
