### PR TITLE
Fix column `ip_address` in table `gcp_compute_forwarding_rule` for IPv6 CIDR values

### DIFF
--- a/gcp/table_gcp_compute_forwarding_rule.go
+++ b/gcp/table_gcp_compute_forwarding_rule.go
@@ -56,7 +56,7 @@ func tableGcpComputeForwardingRule(ctx context.Context) *plugin.Table {
 			{
 				Name:        "ip_address",
 				Description: "Specifies the IP address that this forwarding rule serves.",
-				Type:        proto.ColumnType_IPADDR,
+				Type:        proto.ColumnType_INET,
 				Transform:   transform.FromField("IPAddress"),
 			},
 			{


### PR DESCRIPTION
# Example query results
<details>
  <summary>Results</summary>
  
```sql
> select name, ip_address from gcp_compute_forwarding_rule
+------------------------------------+---------------------------------+
| name                               | ip_address                      |
+------------------------------------+---------------------------------+
| gke-cluster-1-e7df1409-95479c15-pe | 10.128.0.22                     |
| test-fr                            | 2600:1900:4000:45f3:8000:1::/96 |
+------------------------------------+---------------------------------+
```
</details>
