### PR TITLE
Fix the table docs of compute instance metric tables to use the correct value of average Closes #394

### DIFF
--- a/docs/tables/gcp_compute_instance_metric_cpu_utilization.md
+++ b/docs/tables/gcp_compute_instance_metric_cpu_utilization.md
@@ -33,7 +33,8 @@ select
   sample_count
 from
   gcp_compute_instance_metric_cpu_utilization
-where average > 80
+where
+  average > 0.80
 order by
   name,
   timestamp;

--- a/docs/tables/gcp_compute_instance_metric_cpu_utilization_daily.md
+++ b/docs/tables/gcp_compute_instance_metric_cpu_utilization_daily.md
@@ -33,7 +33,8 @@ select
   sample_count
 from
   gcp_compute_instance_metric_cpu_utilization_daily
-where average > 80
+where
+  average > 0.80
 order by
   name,
   timestamp;

--- a/docs/tables/gcp_compute_instance_metric_cpu_utilization_hourly.md
+++ b/docs/tables/gcp_compute_instance_metric_cpu_utilization_hourly.md
@@ -33,7 +33,8 @@ select
   sample_count
 from
   gcp_compute_instance_metric_cpu_utilization_hourly
-where average > 80
+where
+  average > 0.80
 order by
   name,
   timestamp;


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
Add passing integration test logs here
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
Add example SQL query results here (please include the input queries as well)
```
</details>
