### PR TITLE
Update `id` columns to use `proto.ColumnType_INT` for tables `gcp_compute_instance_template`, `gcp_compute_network`, `gcp_compute_target_https_proxy` and `gcp_compute_target_pool`

### DIFF
--- a/gcp/table_gcp_compute_instance_template.go
+++ b/gcp/table_gcp_compute_instance_template.go
@@ -33,7 +33,7 @@ func tableGcpComputeInstanceTemplate(ctx context.Context) *plugin.Table {
 			{
 				Name:        "id",
 				Description: "A unique identifier for this instance template. The server defines this identifier.",
-				Type:        proto.ColumnType_DOUBLE,
+				Type:        proto.ColumnType_INT,
 			},
 			{
 				Name:        "creation_timestamp",

--- a/gcp/table_gcp_compute_network.go
+++ b/gcp/table_gcp_compute_network.go
@@ -37,7 +37,7 @@ func tableGcpComputeNetwork(ctx context.Context) *plugin.Table {
 			{
 				Name:        "id",
 				Description: "The unique identifier for the resource. This identifier is defined by the server.",
-				Type:        proto.ColumnType_DOUBLE,
+				Type:        proto.ColumnType_INT,
 			},
 			{
 				Name:        "creation_timestamp",

--- a/gcp/table_gcp_compute_target_https_proxy.go
+++ b/gcp/table_gcp_compute_target_https_proxy.go
@@ -38,7 +38,7 @@ func tableGcpComputeTargetHttpsProxy(ctx context.Context) *plugin.Table {
 			{
 				Name:        "id",
 				Description: "A server-defined unique identifier for the resource.",
-				Type:        proto.ColumnType_DOUBLE,
+				Type:        proto.ColumnType_INT,
 			},
 			{
 				Name:        "creation_timestamp",

--- a/gcp/table_gcp_compute_target_pool.go
+++ b/gcp/table_gcp_compute_target_pool.go
@@ -37,7 +37,7 @@ func tableGcpComputeTargetPool(ctx context.Context) *plugin.Table {
 			{
 				Name:        "id",
 				Description: "The unique identifier for the resource.",
-				Type:        proto.ColumnType_DOUBLE,
+				Type:        proto.ColumnType_INT,
 			},
 			{
 				Name:        "description",


### PR DESCRIPTION
# Example query results
<details>
  <summary>Results</summary>
  
```sql
> select id, name from gcp_compute_instance_template
+---------------------+-----------------------------------------------------+
| id                  | name                                                |
+---------------------+-----------------------------------------------------+
| 7238835869234810961 | delete-5jan-rk-instance-group-1-instance-template-1 |
+---------------------+-----------------------------------------------------+

> select id, name from gcp_compute_network limit 2
+---------------------+-------------------+
| id                  | name              |
+---------------------+-------------------+
| 428975955104606396  | turbottest2037    |
| 2257324205686403466 | legacy-network176 |
+---------------------+-------------------+
```
</details>
