### PR TITLE
Add ignore_error_codes config option closes #431

### DIFF
--- a/config/gcp.spc
+++ b/config/gcp.spc
@@ -22,5 +22,5 @@ connection "gcp" {
 
   # List of additional GCP error codes to ignore for all queries.
   # By default, common not found error codes are ignored and will still be ignored even if this argument is not set.
-  #ignore_error_codes = ["AccessDenied", "AccessDeniedException", "NotAuthorized", "UnauthorizedOperation", "AuthorizationError", "403"]
+  #ignore_error_codes = ["400", "401", "403"]
 }

--- a/config/gcp.spc
+++ b/config/gcp.spc
@@ -19,4 +19,8 @@ connection "gcp" {
   # `impersonate_service_account` (optional) - The GCP service account (string) which should be impersonated.
   # If not set, no impersonation is done.
   #impersonate_service_account = "YOUR_SERVICE_ACCOUNT"
+
+  # List of additional GCP error codes to ignore for all queries.
+  # By default, common not found error codes are ignored and will still be ignored even if this argument is not set.
+  #ignore_error_codes = ["AccessDenied", "AccessDeniedException", "NotAuthorized", "UnauthorizedOperation", "AuthorizationError", "403"]
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,7 +6,7 @@ brand_color: "#ea4335"
 display_name: "GCP"
 name: "gcp"
 description: "Steampipe plugin for querying buckets, instances, functions and more from GCP."
-og_description: Query GCP with SQL! Open source CLI. No DB required. 
+og_description: Query GCP with SQL! Open source CLI. No DB required.
 og_image: "/images/plugins/turbot/gcp-social-graphic.png"
 ---
 
@@ -86,6 +86,10 @@ connection "gcp" {
   # `impersonate_service_account` (optional) - The GCP service account (string) which should be impersonated.
   # If not set, no impersonation is done.
   #impersonate_service_account = "YOUR_SERVICE_ACCOUNT"
+
+  # `ignore_error_codes` (optional) - List of additional GCP error codes to ignore for all queries.
+  # By default, the common not found error codes are ignored and will still be ignored even if this argument is not set.
+  #ignore_error_codes = ["400", "401", "403"]
 }
 ```
 

--- a/gcp/compute_location_list.go
+++ b/gcp/compute_location_list.go
@@ -12,11 +12,9 @@ import (
 // 	}
 // }
 
-
 // BuildregionList :: return a list of matrix items, one per region specified
 // https://cloud.google.com/dataproc/docs/concepts/regional-endpoints
 func BuildComputeLocationList(ctx context.Context, d *plugin.QueryData) []map[string]interface{} {
-
 
 	// have we already created and cached the locations?
 	locationCacheKey := "Compute"

--- a/gcp/connection_config.go
+++ b/gcp/connection_config.go
@@ -6,10 +6,11 @@ import (
 )
 
 type gcpConfig struct {
-	Project                   *string `cty:"project"`
-	Credentials               *string `cty:"credentials"`
-	CredentialFile            *string `cty:"credential_file"`
-	ImpersonateServiceAccount *string `cty:"impersonate_service_account"`
+	Project                   *string  `cty:"project"`
+	Credentials               *string  `cty:"credentials"`
+	CredentialFile            *string  `cty:"credential_file"`
+	ImpersonateServiceAccount *string  `cty:"impersonate_service_account"`
+	IgnoreErrorCodes          []string `cty:"ignore_error_codes"`
 }
 
 var ConfigSchema = map[string]*schema.Attribute{
@@ -24,6 +25,10 @@ var ConfigSchema = map[string]*schema.Attribute{
 	},
 	"impersonate_service_account": {
 		Type: schema.TypeString,
+	},
+	"ignore_error_codes": {
+		Type: schema.TypeList,
+		Elem: &schema.Attribute{Type: schema.TypeString},
 	},
 }
 

--- a/gcp/ignore_error_predicate.go
+++ b/gcp/ignore_error_predicate.go
@@ -3,7 +3,6 @@ package gcp
 import (
 	"context"
 	"path"
-	"regexp"
 
 	"github.com/turbot/go-kit/helpers"
 	"github.com/turbot/go-kit/types"
@@ -15,11 +14,6 @@ import (
 func isIgnorableError(notFoundErrors []string) plugin.ErrorPredicate {
 	return func(err error) bool {
 		if gerr, ok := err.(*googleapi.Error); ok {
-			if types.ToString(gerr.Code) == "403" {
-				// return true, if service API is disabled
-				regexExp := regexp.MustCompile(`googleapi: Error 403: [^\.]+ API has not been used in project [0-9]+ before or it is disabled\.`)
-				return regexExp.MatchString(err.Error())
-			}
 			return helpers.StringSliceContains(notFoundErrors, types.ToString(gerr.Code))
 		}
 		return false

--- a/gcp/plugin.go
+++ b/gcp/plugin.go
@@ -20,8 +20,9 @@ func Plugin(ctx context.Context) *plugin.Plugin {
 	p := &plugin.Plugin{
 		Name:             pluginName,
 		DefaultTransform: transform.FromCamel(),
-		DefaultGetConfig: &plugin.GetConfig{
-			ShouldIgnoreError: isIgnorableError([]string{"404", "400", "403"}),
+		// Default ignore config for the plugin
+		DefaultIgnoreConfig: &plugin.IgnoreConfig{
+			ShouldIgnoreErrorFunc: shouldIgnoreErrorPluginDefault(),
 		},
 		ConnectionConfigSchema: &plugin.ConnectionConfigSchema{
 			NewInstance: ConfigInstance,

--- a/gcp/plugin.go
+++ b/gcp/plugin.go
@@ -20,6 +20,9 @@ func Plugin(ctx context.Context) *plugin.Plugin {
 	p := &plugin.Plugin{
 		Name:             pluginName,
 		DefaultTransform: transform.FromCamel(),
+		DefaultGetConfig: &plugin.GetConfig{
+			ShouldIgnoreError: isIgnorableError([]string{"404", "400"}),
+		},
 		// Default ignore config for the plugin
 		DefaultIgnoreConfig: &plugin.IgnoreConfig{
 			ShouldIgnoreErrorFunc: shouldIgnoreErrorPluginDefault(),

--- a/gcp/table_gcp_audit_policy.go
+++ b/gcp/table_gcp_audit_policy.go
@@ -17,8 +17,7 @@ func tableGcpAuditPolicy(_ context.Context) *plugin.Table {
 		Name:        "gcp_audit_policy",
 		Description: "GCP Audit Policy",
 		List: &plugin.ListConfig{
-			Hydrate:           listGcpAuditPolicies,
-			ShouldIgnoreError: isIgnorableError([]string{"403"}),
+			Hydrate: listGcpAuditPolicies,
 		},
 		Columns: []*plugin.Column{
 			{

--- a/gcp/table_gcp_bigquery_dataset.go
+++ b/gcp/table_gcp_bigquery_dataset.go
@@ -23,8 +23,7 @@ func tableGcpBigQueryDataset(ctx context.Context) *plugin.Table {
 			Hydrate:    getBigQueryDataset,
 		},
 		List: &plugin.ListConfig{
-			Hydrate:           listBigQueryDatasets,
-			ShouldIgnoreError: isIgnorableError([]string{"403"}),
+			Hydrate: listBigQueryDatasets,
 		},
 		Columns: []*plugin.Column{
 			{

--- a/gcp/table_gcp_bigquery_job.go
+++ b/gcp/table_gcp_bigquery_job.go
@@ -22,8 +22,7 @@ func tableGcpBigQueryJob(ctx context.Context) *plugin.Table {
 			Hydrate:    getBigQueryJob,
 		},
 		List: &plugin.ListConfig{
-			Hydrate:           listBigQueryJobs,
-			ShouldIgnoreError: isIgnorableError([]string{"403"}),
+			Hydrate: listBigQueryJobs,
 		},
 		Columns: []*plugin.Column{
 			{

--- a/gcp/table_gcp_bigquery_table.go
+++ b/gcp/table_gcp_bigquery_table.go
@@ -22,9 +22,8 @@ func tableGcpBigqueryTable(ctx context.Context) *plugin.Table {
 			Hydrate:    getBigqueryTable,
 		},
 		List: &plugin.ListConfig{
-			ParentHydrate:     listBigQueryDatasets,
-			Hydrate:           listBigqueryTables,
-			ShouldIgnoreError: isIgnorableError([]string{"403"}),
+			ParentHydrate: listBigQueryDatasets,
+			Hydrate:       listBigqueryTables,
 		},
 		Columns: []*plugin.Column{
 			{

--- a/gcp/table_gcp_bigtable_instance.go
+++ b/gcp/table_gcp_bigtable_instance.go
@@ -22,8 +22,7 @@ func tableGcpBigtableInstance(ctx context.Context) *plugin.Table {
 			Hydrate:    getBigtableInstance,
 		},
 		List: &plugin.ListConfig{
-			Hydrate:           listBigtableInstances,
-			ShouldIgnoreError: isIgnorableError([]string{"403"}),
+			Hydrate: listBigtableInstances,
 		},
 		Columns: []*plugin.Column{
 			{

--- a/gcp/table_gcp_cloudfunctions_function.go
+++ b/gcp/table_gcp_cloudfunctions_function.go
@@ -22,8 +22,7 @@ func tableGcpCloudfunctionFunction(ctx context.Context) *plugin.Table {
 			Hydrate:    getCloudFunction,
 		},
 		List: &plugin.ListConfig{
-			Hydrate:           listCloudFunctions,
-			ShouldIgnoreError: isIgnorableError([]string{"403"}),
+			Hydrate: listCloudFunctions,
 		},
 		Columns: []*plugin.Column{
 			{

--- a/gcp/table_gcp_compute_address.go
+++ b/gcp/table_gcp_compute_address.go
@@ -23,8 +23,7 @@ func tableGcpComputeAddress(ctx context.Context) *plugin.Table {
 			Hydrate:    getComputeAddress,
 		},
 		List: &plugin.ListConfig{
-			Hydrate:           listComputeAddresses,
-			ShouldIgnoreError: isIgnorableError([]string{"403"}),
+			Hydrate: listComputeAddresses,
 			KeyColumns: plugin.KeyColumnSlice{
 				// String columns
 				{Name: "address_type", Require: plugin.Optional, Operators: []string{"<>", "="}},
@@ -262,7 +261,7 @@ func getComputeAddress(ctx context.Context, d *plugin.QueryData, h *plugin.Hydra
 
 func addressSelfLinkToTurbotData(ctx context.Context, d *transform.TransformData) (interface{}, error) {
 	address := d.HydrateItem.(*compute.Address)
-	
+
 	param := d.Param.(string)
 	region := getLastPathElement(types.SafeString(address.Region))
 	project := strings.Split(address.SelfLink, "/")[6]

--- a/gcp/table_gcp_compute_autoscaler.go
+++ b/gcp/table_gcp_compute_autoscaler.go
@@ -20,8 +20,7 @@ func tableGcpComputeAutoscaler(ctx context.Context) *plugin.Table {
 			Hydrate:    getComputeAutoscaler,
 		},
 		List: &plugin.ListConfig{
-			Hydrate:           listComputeAutoscaler,
-			ShouldIgnoreError: isIgnorableError([]string{"403"}),
+			Hydrate: listComputeAutoscaler,
 		},
 		Columns: []*plugin.Column{
 			{

--- a/gcp/table_gcp_compute_backend_bucket.go
+++ b/gcp/table_gcp_compute_backend_bucket.go
@@ -23,8 +23,7 @@ func tableGcpComputeBackendBucket(ctx context.Context) *plugin.Table {
 			Hydrate:    getComputeBackendBucket,
 		},
 		List: &plugin.ListConfig{
-			Hydrate:           listComputeBackendBuckets,
-			ShouldIgnoreError: isIgnorableError([]string{"403"}),
+			Hydrate: listComputeBackendBuckets,
 			KeyColumns: plugin.KeyColumnSlice{
 				// String columns
 				{Name: "bucket_name", Require: plugin.Optional, Operators: []string{"<>", "="}},

--- a/gcp/table_gcp_compute_backend_service.go
+++ b/gcp/table_gcp_compute_backend_service.go
@@ -23,8 +23,7 @@ func tableGcpComputeBackendService(ctx context.Context) *plugin.Table {
 			Hydrate:    getComputeBackendService,
 		},
 		List: &plugin.ListConfig{
-			Hydrate:           listComputeBackendServices,
-			ShouldIgnoreError: isIgnorableError([]string{"403"}),
+			Hydrate: listComputeBackendServices,
 			KeyColumns: plugin.KeyColumnSlice{
 				// String columns
 				{Name: "load_balancing_scheme", Require: plugin.Optional, Operators: []string{"<>", "="}},

--- a/gcp/table_gcp_compute_disk.go
+++ b/gcp/table_gcp_compute_disk.go
@@ -20,8 +20,7 @@ func tableGcpComputeDisk(ctx context.Context) *plugin.Table {
 			Hydrate:    getComputeDisk,
 		},
 		List: &plugin.ListConfig{
-			Hydrate:           listComputeDisk,
-			ShouldIgnoreError: isIgnorableError([]string{"403"}),
+			Hydrate: listComputeDisk,
 			KeyColumns: plugin.KeyColumnSlice{
 				// String columns
 				{Name: "name", Require: plugin.Optional, Operators: []string{"<>", "="}},

--- a/gcp/table_gcp_compute_disk_metric_read_ops.go
+++ b/gcp/table_gcp_compute_disk_metric_read_ops.go
@@ -17,10 +17,9 @@ func tableGcpComputeDiskMetricReadOps(_ context.Context) *plugin.Table {
 		Name:        "gcp_compute_disk_metric_read_ops",
 		Description: "GCP Compute Disk Metrics - Read Ops",
 		List: &plugin.ListConfig{
-			ParentHydrate:     listComputeDisk,
-			Hydrate:           listComputeDiskMetricReadOps,
-			ShouldIgnoreError: isIgnorableError([]string{"403"}),
-			KeyColumns:        plugin.OptionalColumns([]string{"name"}),
+			ParentHydrate: listComputeDisk,
+			Hydrate:       listComputeDiskMetricReadOps,
+			KeyColumns:    plugin.OptionalColumns([]string{"name"}),
 		},
 		Columns: monitoringMetricColumns([]*plugin.Column{
 			{

--- a/gcp/table_gcp_compute_disk_metric_read_ops_daily.go
+++ b/gcp/table_gcp_compute_disk_metric_read_ops_daily.go
@@ -17,10 +17,9 @@ func tableGcpComputeDiskMetricReadOpsDaily(_ context.Context) *plugin.Table {
 		Name:        "gcp_compute_disk_metric_read_ops_daily",
 		Description: "GCP Compute Disk Metrics - Read Ops (Daily)",
 		List: &plugin.ListConfig{
-			ParentHydrate:     listComputeDisk,
-			Hydrate:           listComputeDiskMetricReadOpsDaily,
-			ShouldIgnoreError: isIgnorableError([]string{"403"}),
-			KeyColumns:        plugin.OptionalColumns([]string{"name"}),
+			ParentHydrate: listComputeDisk,
+			Hydrate:       listComputeDiskMetricReadOpsDaily,
+			KeyColumns:    plugin.OptionalColumns([]string{"name"}),
 		},
 		Columns: monitoringMetricColumns([]*plugin.Column{
 			{

--- a/gcp/table_gcp_compute_disk_metric_read_ops_hourly.go
+++ b/gcp/table_gcp_compute_disk_metric_read_ops_hourly.go
@@ -17,10 +17,9 @@ func tableGcpComputeDiskMetricReadOpsHourly(_ context.Context) *plugin.Table {
 		Name:        "gcp_compute_disk_metric_read_ops_hourly",
 		Description: "GCP Compute Disk Metrics - Read Ops (Hourly)",
 		List: &plugin.ListConfig{
-			ParentHydrate:     listComputeDisk,
-			Hydrate:           listComputeDiskMetricReadOpsHourly,
-			ShouldIgnoreError: isIgnorableError([]string{"403"}),
-			KeyColumns:        plugin.OptionalColumns([]string{"name"}),
+			ParentHydrate: listComputeDisk,
+			Hydrate:       listComputeDiskMetricReadOpsHourly,
+			KeyColumns:    plugin.OptionalColumns([]string{"name"}),
 		},
 		Columns: monitoringMetricColumns([]*plugin.Column{
 			{

--- a/gcp/table_gcp_compute_disk_metric_write_ops.go
+++ b/gcp/table_gcp_compute_disk_metric_write_ops.go
@@ -17,10 +17,9 @@ func tableGcpComputeDiskMetricWriteOps(_ context.Context) *plugin.Table {
 		Name:        "gcp_compute_disk_metric_write_ops",
 		Description: "GCP Compute Disk Metrics - Write Ops",
 		List: &plugin.ListConfig{
-			ParentHydrate:     listComputeDisk,
-			Hydrate:           listComputeDiskMetricWriteOps,
-			ShouldIgnoreError: isIgnorableError([]string{"403"}),
-			KeyColumns:        plugin.OptionalColumns([]string{"name"}),
+			ParentHydrate: listComputeDisk,
+			Hydrate:       listComputeDiskMetricWriteOps,
+			KeyColumns:    plugin.OptionalColumns([]string{"name"}),
 		},
 		Columns: monitoringMetricColumns([]*plugin.Column{
 			{

--- a/gcp/table_gcp_compute_disk_metric_write_ops_daily.go
+++ b/gcp/table_gcp_compute_disk_metric_write_ops_daily.go
@@ -17,10 +17,9 @@ func tableGcpComputeDiskMetricWriteOpsDaily(_ context.Context) *plugin.Table {
 		Name:        "gcp_compute_disk_metric_write_ops_daily",
 		Description: "GCP Compute Disk Metrics - Write Ops (Daily)",
 		List: &plugin.ListConfig{
-			ParentHydrate:     listComputeDisk,
-			Hydrate:           listComputeDiskMetricWriteOpsDaily,
-			ShouldIgnoreError: isIgnorableError([]string{"403"}),
-			KeyColumns:        plugin.OptionalColumns([]string{"name"}),
+			ParentHydrate: listComputeDisk,
+			Hydrate:       listComputeDiskMetricWriteOpsDaily,
+			KeyColumns:    plugin.OptionalColumns([]string{"name"}),
 		},
 		Columns: monitoringMetricColumns([]*plugin.Column{
 			{

--- a/gcp/table_gcp_compute_disk_metric_write_ops_hourly.go
+++ b/gcp/table_gcp_compute_disk_metric_write_ops_hourly.go
@@ -17,10 +17,9 @@ func tableGcpComputeDiskMetricWriteOpsHourly(_ context.Context) *plugin.Table {
 		Name:        "gcp_compute_disk_metric_write_ops_hourly",
 		Description: "GCP Compute Disk Metrics - Write Ops (Hourly)",
 		List: &plugin.ListConfig{
-			ParentHydrate:     listComputeDisk,
-			Hydrate:           listComputeDiskMetricWriteOpsHourly,
-			ShouldIgnoreError: isIgnorableError([]string{"403"}),
-			KeyColumns:        plugin.OptionalColumns([]string{"name"}),
+			ParentHydrate: listComputeDisk,
+			Hydrate:       listComputeDiskMetricWriteOpsHourly,
+			KeyColumns:    plugin.OptionalColumns([]string{"name"}),
 		},
 		Columns: monitoringMetricColumns([]*plugin.Column{
 			{

--- a/gcp/table_gcp_compute_firewall.go
+++ b/gcp/table_gcp_compute_firewall.go
@@ -23,8 +23,7 @@ func tableGcpComputeFirewall(ctx context.Context) *plugin.Table {
 			Hydrate:    getComputeFirewall,
 		},
 		List: &plugin.ListConfig{
-			Hydrate:           listComputeFirewalls,
-			ShouldIgnoreError: isIgnorableError([]string{"403"}),
+			Hydrate: listComputeFirewalls,
 			KeyColumns: plugin.KeyColumnSlice{
 				// String columns
 				{Name: "direction", Require: plugin.Optional, Operators: []string{"<>", "="}},

--- a/gcp/table_gcp_compute_forwarding_rule.go
+++ b/gcp/table_gcp_compute_forwarding_rule.go
@@ -23,8 +23,7 @@ func tableGcpComputeForwardingRule(ctx context.Context) *plugin.Table {
 			Hydrate:    getComputeForwardingRule,
 		},
 		List: &plugin.ListConfig{
-			Hydrate:           listComputeForwardingRules,
-			ShouldIgnoreError: isIgnorableError([]string{"403"}),
+			Hydrate: listComputeForwardingRules,
 			KeyColumns: plugin.KeyColumnSlice{
 				// String columns
 				{Name: "ip_protocol", Require: plugin.Optional, Operators: []string{"<>", "="}},

--- a/gcp/table_gcp_compute_global_address.go
+++ b/gcp/table_gcp_compute_global_address.go
@@ -23,8 +23,7 @@ func tableGcpComputeGlobalAddress(ctx context.Context) *plugin.Table {
 			Hydrate:    getComputeGlobalAddress,
 		},
 		List: &plugin.ListConfig{
-			Hydrate:           listComputeGlobalAddresses,
-			ShouldIgnoreError: isIgnorableError([]string{"403"}),
+			Hydrate: listComputeGlobalAddresses,
 			KeyColumns: plugin.KeyColumnSlice{
 				// String columns
 				{Name: "address_type", Require: plugin.Optional, Operators: []string{"<>", "="}},

--- a/gcp/table_gcp_compute_global_forwarding_rule.go
+++ b/gcp/table_gcp_compute_global_forwarding_rule.go
@@ -23,8 +23,7 @@ func tableGcpComputeGlobalForwardingRule(ctx context.Context) *plugin.Table {
 			Hydrate:    getComputeGlobalForwardingRule,
 		},
 		List: &plugin.ListConfig{
-			Hydrate:           listComputeGlobalForwardingRules,
-			ShouldIgnoreError: isIgnorableError([]string{"403"}),
+			Hydrate: listComputeGlobalForwardingRules,
 			KeyColumns: plugin.KeyColumnSlice{
 				// String columns
 				{Name: "ip_protocol", Require: plugin.Optional, Operators: []string{"<>", "="}},

--- a/gcp/table_gcp_compute_ha_vpn_gateway.go
+++ b/gcp/table_gcp_compute_ha_vpn_gateway.go
@@ -22,8 +22,7 @@ func tableGcpComputeHaVpnGateway(ctx context.Context) *plugin.Table {
 			Hydrate:    getComputeHaVpnGateway,
 		},
 		List: &plugin.ListConfig{
-			Hydrate: 					 listComputeHaVpnGateways,
-			ShouldIgnoreError: isIgnorableError([]string{"403"}),
+			Hydrate: listComputeHaVpnGateways,
 		},
 		Columns: []*plugin.Column{
 			{

--- a/gcp/table_gcp_compute_image.go
+++ b/gcp/table_gcp_compute_image.go
@@ -26,7 +26,7 @@ func tableGcpComputeImage(ctx context.Context) *plugin.Table {
 		List: &plugin.ListConfig{
 			ParentHydrate:     listComputeImageProjects,
 			Hydrate:           listImagesForProject,
-			ShouldIgnoreError: isIgnorableError([]string{"403", "404"}),
+			ShouldIgnoreError: isIgnorableError([]string{"404"}),
 			KeyColumns: plugin.KeyColumnSlice{
 				{Name: "deprecation_state", Require: plugin.Optional},
 				{Name: "family", Require: plugin.Optional},

--- a/gcp/table_gcp_compute_instance.go
+++ b/gcp/table_gcp_compute_instance.go
@@ -22,8 +22,7 @@ func tableGcpComputeInstance(ctx context.Context) *plugin.Table {
 			Hydrate:    getComputeInstance,
 		},
 		List: &plugin.ListConfig{
-			Hydrate:           listComputeInstances,
-			ShouldIgnoreError: isIgnorableError([]string{"403"}),
+			Hydrate: listComputeInstances,
 			KeyColumns: plugin.KeyColumnSlice{
 				// String columns
 				{Name: "name", Require: plugin.Optional, Operators: []string{"<>", "="}},

--- a/gcp/table_gcp_compute_instance_group.go
+++ b/gcp/table_gcp_compute_instance_group.go
@@ -20,8 +20,7 @@ func tableGcpComputeInstanceGroup(ctx context.Context) *plugin.Table {
 			Hydrate:    getComputeInstanceGroup,
 		},
 		List: &plugin.ListConfig{
-			Hydrate: 					 listComputeInstanceGroup,
-			ShouldIgnoreError: isIgnorableError([]string{"403"}),
+			Hydrate: listComputeInstanceGroup,
 		},
 		Columns: []*plugin.Column{
 			{

--- a/gcp/table_gcp_compute_instance_metric_cpu_utilization.go
+++ b/gcp/table_gcp_compute_instance_metric_cpu_utilization.go
@@ -16,10 +16,9 @@ func tableGcpComputeInstanceMetricCpuUtilization(_ context.Context) *plugin.Tabl
 		Name:        "gcp_compute_instance_metric_cpu_utilization",
 		Description: "GCP Compute Instance Metrics - CPU Utilization",
 		List: &plugin.ListConfig{
-			ParentHydrate:     listComputeInstances,
-			Hydrate:           listComputeInstanceMetricCpuUtilization,
-			ShouldIgnoreError: isIgnorableError([]string{"403"}),
-			KeyColumns:        plugin.OptionalColumns([]string{"name"}),
+			ParentHydrate: listComputeInstances,
+			Hydrate:       listComputeInstanceMetricCpuUtilization,
+			KeyColumns:    plugin.OptionalColumns([]string{"name"}),
 		},
 		Columns: monitoringMetricColumns([]*plugin.Column{
 			{

--- a/gcp/table_gcp_compute_instance_metric_cpu_utilization_daily.go
+++ b/gcp/table_gcp_compute_instance_metric_cpu_utilization_daily.go
@@ -16,10 +16,9 @@ func tableGcpComputeInstanceMetricCpuUtilizationDaily(_ context.Context) *plugin
 		Name:        "gcp_compute_instance_metric_cpu_utilization_daily",
 		Description: "GCP Compute Instance Metrics - CPU Utilization (Daily)",
 		List: &plugin.ListConfig{
-			ParentHydrate:     listComputeInstances,
-			Hydrate:           listComputeInstanceMetricCpuUtilizationDaily,
-			ShouldIgnoreError: isIgnorableError([]string{"403"}),
-			KeyColumns:        plugin.OptionalColumns([]string{"name"}),
+			ParentHydrate: listComputeInstances,
+			Hydrate:       listComputeInstanceMetricCpuUtilizationDaily,
+			KeyColumns:    plugin.OptionalColumns([]string{"name"}),
 		},
 		Columns: monitoringMetricColumns([]*plugin.Column{
 			{

--- a/gcp/table_gcp_compute_instance_metric_cpu_utilization_hourly.go
+++ b/gcp/table_gcp_compute_instance_metric_cpu_utilization_hourly.go
@@ -16,10 +16,9 @@ func tableGcpComputeInstanceMetricCpuUtilizationHourly(_ context.Context) *plugi
 		Name:        "gcp_compute_instance_metric_cpu_utilization_hourly",
 		Description: "GCP Compute Instance Metrics - CPU Utilization (Hourly)",
 		List: &plugin.ListConfig{
-			ParentHydrate:     listComputeInstances,
-			Hydrate:           listComputeInstanceMetricCpuUtilizationHourly,
-			ShouldIgnoreError: isIgnorableError([]string{"403"}),
-			KeyColumns:        plugin.OptionalColumns([]string{"name"}),
+			ParentHydrate: listComputeInstances,
+			Hydrate:       listComputeInstanceMetricCpuUtilizationHourly,
+			KeyColumns:    plugin.OptionalColumns([]string{"name"}),
 		},
 		Columns: monitoringMetricColumns([]*plugin.Column{
 			{

--- a/gcp/table_gcp_compute_instance_template.go
+++ b/gcp/table_gcp_compute_instance_template.go
@@ -21,8 +21,7 @@ func tableGcpComputeInstanceTemplate(ctx context.Context) *plugin.Table {
 			Hydrate:    getComputeInstanceTemplate,
 		},
 		List: &plugin.ListConfig{
-			Hydrate:           listComputeInstanceTemplate,
-			ShouldIgnoreError: isIgnorableError([]string{"403"}),
+			Hydrate: listComputeInstanceTemplate,
 		},
 		Columns: []*plugin.Column{
 			{

--- a/gcp/table_gcp_compute_machine_type.go
+++ b/gcp/table_gcp_compute_machine_type.go
@@ -22,8 +22,7 @@ func tableGcpComputeMachineType(ctx context.Context) *plugin.Table {
 			Hydrate:    getComputeMachineType,
 		},
 		List: &plugin.ListConfig{
-			Hydrate:           listComputeMachineTypes,
-			ShouldIgnoreError: isIgnorableError([]string{"403"}),
+			Hydrate: listComputeMachineTypes,
 		},
 		Columns: []*plugin.Column{
 			{

--- a/gcp/table_gcp_compute_network.go
+++ b/gcp/table_gcp_compute_network.go
@@ -20,8 +20,7 @@ func tableGcpComputeNetwork(ctx context.Context) *plugin.Table {
 			Hydrate:    getComputeNetwork,
 		},
 		List: &plugin.ListConfig{
-			Hydrate:           listComputeNetworks,
-			ShouldIgnoreError: isIgnorableError([]string{"403"}),
+			Hydrate: listComputeNetworks,
 			KeyColumns: plugin.KeyColumnSlice{
 				// Boolean columns
 				{Name: "auto_create_subnetworks", Require: plugin.Optional, Operators: []string{"<>", "="}},

--- a/gcp/table_gcp_compute_node_group.go
+++ b/gcp/table_gcp_compute_node_group.go
@@ -23,8 +23,7 @@ func tableGcpComputeNodeGroup(ctx context.Context) *plugin.Table {
 			Hydrate:    getComputeNodeGroup,
 		},
 		List: &plugin.ListConfig{
-			Hydrate:           listComputeNodeGroups,
-			ShouldIgnoreError: isIgnorableError([]string{"403"}),
+			Hydrate: listComputeNodeGroups,
 			KeyColumns: plugin.KeyColumnSlice{
 				// String columns
 				{Name: "status", Require: plugin.Optional, Operators: []string{"<>", "="}},

--- a/gcp/table_gcp_compute_node_template.go
+++ b/gcp/table_gcp_compute_node_template.go
@@ -23,8 +23,7 @@ func tableGcpComputeNodeTemplate(ctx context.Context) *plugin.Table {
 			Hydrate:    getComputeNodeTemplate,
 		},
 		List: &plugin.ListConfig{
-			Hydrate:           listComputeNodeTemplates,
-			ShouldIgnoreError: isIgnorableError([]string{"403"}),
+			Hydrate: listComputeNodeTemplates,
 			KeyColumns: plugin.KeyColumnSlice{
 				// String columns
 				{Name: "cpu_overcommit_type", Require: plugin.Optional, Operators: []string{"<>", "="}},

--- a/gcp/table_gcp_compute_project_metadata.go
+++ b/gcp/table_gcp_compute_project_metadata.go
@@ -13,8 +13,7 @@ func tableGcpComputeProjectMetadata(ctx context.Context) *plugin.Table {
 		Name:        "gcp_compute_project_metadata",
 		Description: "GCP Compute Project Metadata",
 		List: &plugin.ListConfig{
-			Hydrate:           listComputeProjectMetadata,
-			ShouldIgnoreError: isIgnorableError([]string{"403"}),
+			Hydrate: listComputeProjectMetadata,
 		},
 		Columns: []*plugin.Column{
 			{

--- a/gcp/table_gcp_compute_region.go
+++ b/gcp/table_gcp_compute_region.go
@@ -17,8 +17,7 @@ func tableGcpComputeRegion(ctx context.Context) *plugin.Table {
 		Name:        "gcp_compute_region",
 		Description: "GCP Compute Region",
 		List: &plugin.ListConfig{
-			Hydrate:           listComputeRegions,
-			ShouldIgnoreError: isIgnorableError([]string{"403"}),
+			Hydrate: listComputeRegions,
 			KeyColumns: plugin.KeyColumnSlice{
 				// String columns
 				{Name: "name", Require: plugin.Optional, Operators: []string{"<>", "="}},

--- a/gcp/table_gcp_compute_resource_policy.go
+++ b/gcp/table_gcp_compute_resource_policy.go
@@ -23,8 +23,7 @@ func tableGcpComputeResourcePolicy(ctx context.Context) *plugin.Table {
 			Hydrate:    getComputeResourcePolicy,
 		},
 		List: &plugin.ListConfig{
-			Hydrate:           listComputeResourcePolicies,
-			ShouldIgnoreError: isIgnorableError([]string{"403"}),
+			Hydrate: listComputeResourcePolicies,
 			KeyColumns: plugin.KeyColumnSlice{
 				// String columns
 				{Name: "status", Require: plugin.Optional, Operators: []string{"<>", "="}},

--- a/gcp/table_gcp_compute_router.go
+++ b/gcp/table_gcp_compute_router.go
@@ -23,8 +23,7 @@ func tableGcpComputeRouter(ctx context.Context) *plugin.Table {
 			Hydrate:    getComputeRouter,
 		},
 		List: &plugin.ListConfig{
-			Hydrate:           listComputeRouters,
-			ShouldIgnoreError: isIgnorableError([]string{"403"}),
+			Hydrate: listComputeRouters,
 		},
 		Columns: []*plugin.Column{
 			{

--- a/gcp/table_gcp_compute_snapshot.go
+++ b/gcp/table_gcp_compute_snapshot.go
@@ -20,8 +20,7 @@ func tableGcpComputeSnapshot(ctx context.Context) *plugin.Table {
 			Hydrate:    getComputeSnapshot,
 		},
 		List: &plugin.ListConfig{
-			Hydrate:           listComputeSnapshots,
-			ShouldIgnoreError: isIgnorableError([]string{"403"}),
+			Hydrate: listComputeSnapshots,
 			KeyColumns: plugin.KeyColumnSlice{
 				// String columns
 				{Name: "status", Require: plugin.Optional, Operators: []string{"<>", "="}},

--- a/gcp/table_gcp_compute_ssl_policy.go
+++ b/gcp/table_gcp_compute_ssl_policy.go
@@ -23,8 +23,7 @@ func tableGcpComputeSslPolicy(ctx context.Context) *plugin.Table {
 			Hydrate:    getComputeSslPolicy,
 		},
 		List: &plugin.ListConfig{
-			Hydrate:           listComputeSslPolicies,
-			ShouldIgnoreError: isIgnorableError([]string{"403"}),
+			Hydrate: listComputeSslPolicies,
 			KeyColumns: plugin.KeyColumnSlice{
 				// String columns
 				{Name: "min_tls_version", Require: plugin.Optional, Operators: []string{"<>", "="}},

--- a/gcp/table_gcp_compute_subnetwork.go
+++ b/gcp/table_gcp_compute_subnetwork.go
@@ -21,8 +21,7 @@ func tableGcpComputeSubnetwork(ctx context.Context) *plugin.Table {
 			Hydrate:    getComputeSubnetwork,
 		},
 		List: &plugin.ListConfig{
-			Hydrate:           listComputeSubnetworks,
-			ShouldIgnoreError: isIgnorableError([]string{"403"}),
+			Hydrate: listComputeSubnetworks,
 			KeyColumns: plugin.KeyColumnSlice{
 				// String columns
 				{Name: "state", Require: plugin.Optional, Operators: []string{"<>", "="}},

--- a/gcp/table_gcp_compute_target_https_proxy.go
+++ b/gcp/table_gcp_compute_target_https_proxy.go
@@ -22,8 +22,7 @@ func tableGcpComputeTargetHttpsProxy(ctx context.Context) *plugin.Table {
 			Hydrate:    getComputeTargetHttpsProxy,
 		},
 		List: &plugin.ListConfig{
-			Hydrate:           listComputeTargetHttpsProxies,
-			ShouldIgnoreError: isIgnorableError([]string{"403"}),
+			Hydrate: listComputeTargetHttpsProxies,
 			KeyColumns: plugin.KeyColumnSlice{
 				// Boolean columns
 				{Name: "proxy_bind", Require: plugin.Optional, Operators: []string{"<>", "="}},

--- a/gcp/table_gcp_compute_target_pool.go
+++ b/gcp/table_gcp_compute_target_pool.go
@@ -21,8 +21,7 @@ func tableGcpComputeTargetPool(ctx context.Context) *plugin.Table {
 			Hydrate:    getComputeTargetPool,
 		},
 		List: &plugin.ListConfig{
-			Hydrate:           listComputeTargetPools,
-			ShouldIgnoreError: isIgnorableError([]string{"403"}),
+			Hydrate: listComputeTargetPools,
 			KeyColumns: plugin.KeyColumnSlice{
 				// String columns
 				{Name: "session_affinity", Require: plugin.Optional, Operators: []string{"<>", "="}},

--- a/gcp/table_gcp_compute_target_ssl_proxy.go
+++ b/gcp/table_gcp_compute_target_ssl_proxy.go
@@ -23,8 +23,7 @@ func tableGcpComputeTargetSslProxy(ctx context.Context) *plugin.Table {
 			Hydrate:    getComputeTargetSslProxy,
 		},
 		List: &plugin.ListConfig{
-			Hydrate:           listComputeTargetSslProxies,
-			ShouldIgnoreError: isIgnorableError([]string{"403"}),
+			Hydrate: listComputeTargetSslProxies,
 			KeyColumns: plugin.KeyColumnSlice{
 				// String columns
 				{Name: "proxy_header", Require: plugin.Optional, Operators: []string{"<>", "="}},

--- a/gcp/table_gcp_compute_target_vpn_gateway.go
+++ b/gcp/table_gcp_compute_target_vpn_gateway.go
@@ -23,8 +23,7 @@ func tableGcpComputeTargetVpnGateway(ctx context.Context) *plugin.Table {
 			Hydrate:    getComputeTargetVpnGateway,
 		},
 		List: &plugin.ListConfig{
-			Hydrate:           listComputeTargetVpnGateways,
-			ShouldIgnoreError: isIgnorableError([]string{"403"}),
+			Hydrate: listComputeTargetVpnGateways,
 			KeyColumns: plugin.KeyColumnSlice{
 				// String columns
 				{Name: "status", Require: plugin.Optional, Operators: []string{"<>", "="}},

--- a/gcp/table_gcp_compute_url_map.go
+++ b/gcp/table_gcp_compute_url_map.go
@@ -23,8 +23,7 @@ func tableGcpComputeURLMap(ctx context.Context) *plugin.Table {
 			Hydrate:    getComputeURLMap,
 		},
 		List: &plugin.ListConfig{
-			Hydrate:           listComputeURLMaps,
-			ShouldIgnoreError: isIgnorableError([]string{"403"}),
+			Hydrate: listComputeURLMaps,
 		},
 		Columns: []*plugin.Column{
 			{

--- a/gcp/table_gcp_compute_vpn_tunnel.go
+++ b/gcp/table_gcp_compute_vpn_tunnel.go
@@ -23,8 +23,7 @@ func tableGcpComputeVpnTunnel(ctx context.Context) *plugin.Table {
 			Hydrate:    getComputeVpnTunnel,
 		},
 		List: &plugin.ListConfig{
-			Hydrate:           listComputeVpnTunnels,
-			ShouldIgnoreError: isIgnorableError([]string{"403"}),
+			Hydrate: listComputeVpnTunnels,
 			KeyColumns: plugin.KeyColumnSlice{
 				// String columns
 				{Name: "vpn_gateway", Require: plugin.Optional, Operators: []string{"<>", "="}},

--- a/gcp/table_gcp_compute_zone.go
+++ b/gcp/table_gcp_compute_zone.go
@@ -17,8 +17,7 @@ func tableGcpComputeZone(ctx context.Context) *plugin.Table {
 		Name:        "gcp_compute_zone",
 		Description: "GCP Compute Zone",
 		List: &plugin.ListConfig{
-			Hydrate:           listComputeZones,
-			ShouldIgnoreError: isIgnorableError([]string{"403"}),
+			Hydrate: listComputeZones,
 			KeyColumns: plugin.KeyColumnSlice{
 				// String columns
 				{Name: "name", Require: plugin.Optional, Operators: []string{"<>", "="}},

--- a/gcp/table_gcp_dataproc_cluster.go
+++ b/gcp/table_gcp_dataproc_cluster.go
@@ -135,7 +135,7 @@ func listDataprocClusters(ctx context.Context, d *plugin.QueryData, h *plugin.Hy
 		return nil, err
 	}
 
-var filters []string
+	var filters []string
 	if d.KeyColumnQualString("cluster_name") != "" {
 		filters = append(filters, fmt.Sprint("clusterName = ", d.KeyColumnQualString("cluster_name")))
 	}

--- a/gcp/table_gcp_dns_managed_zone.go
+++ b/gcp/table_gcp_dns_managed_zone.go
@@ -22,8 +22,7 @@ func tableGcpDnsManagedZone(ctx context.Context) *plugin.Table {
 			Hydrate:    getDnsManagedZone,
 		},
 		List: &plugin.ListConfig{
-			Hydrate:           listDnsManagedZones,
-			ShouldIgnoreError: isIgnorableError([]string{"403"}),
+			Hydrate: listDnsManagedZones,
 		},
 		Columns: []*plugin.Column{
 			{

--- a/gcp/table_gcp_dns_policy.go
+++ b/gcp/table_gcp_dns_policy.go
@@ -21,8 +21,7 @@ func tableDnsPolicy(ctx context.Context) *plugin.Table {
 			Hydrate:    getDnsPolicy,
 		},
 		List: &plugin.ListConfig{
-			Hydrate:           listDnsPolicies,
-			ShouldIgnoreError: isIgnorableError([]string{"403"}),
+			Hydrate: listDnsPolicies,
 		},
 		Columns: []*plugin.Column{
 			{

--- a/gcp/table_gcp_dns_record_set.go
+++ b/gcp/table_gcp_dns_record_set.go
@@ -26,9 +26,8 @@ func tableDnsRecordSet(ctx context.Context) *plugin.Table {
 			Hydrate:    getDnsRecordSet,
 		},
 		List: &plugin.ListConfig{
-			Hydrate:           listDnsRecordSets,
-			ParentHydrate:     listDnsManagedZones,
-			ShouldIgnoreError: isIgnorableError([]string{"403"}),
+			Hydrate:       listDnsRecordSets,
+			ParentHydrate: listDnsManagedZones,
 		},
 		Columns: []*plugin.Column{
 			{

--- a/gcp/table_gcp_iam_policy.go
+++ b/gcp/table_gcp_iam_policy.go
@@ -18,8 +18,7 @@ func tableGcpIAMPolicy(ctx context.Context) *plugin.Table {
 		Name:        "gcp_iam_policy",
 		Description: "GCP IAM Policy",
 		List: &plugin.ListConfig{
-			Hydrate:           listGcpIamPolicies,
-			ShouldIgnoreError: isIgnorableError([]string{"403"}),
+			Hydrate: listGcpIamPolicies,
 		},
 		Columns: []*plugin.Column{
 			{

--- a/gcp/table_gcp_iam_role.go
+++ b/gcp/table_gcp_iam_role.go
@@ -24,8 +24,7 @@ func tableGcpIamRole(_ context.Context) *plugin.Table {
 			Hydrate:    getIamRole,
 		},
 		List: &plugin.ListConfig{
-			Hydrate:           listIamRoles,
-			ShouldIgnoreError: isIgnorableError([]string{"403"}),
+			Hydrate: listIamRoles,
 			KeyColumns: plugin.KeyColumnSlice{
 				{Name: "is_gcp_managed", Require: plugin.Optional, Operators: []string{"<>", "="}},
 			},

--- a/gcp/table_gcp_kms_key.go
+++ b/gcp/table_gcp_kms_key.go
@@ -22,9 +22,8 @@ func tableGcpKmsKey(ctx context.Context) *plugin.Table {
 			Hydrate:    getKeyDetail,
 		},
 		List: &plugin.ListConfig{
-			Hydrate:           listKeyDetails,
-			ParentHydrate:     listKeyRingDetails,
-			ShouldIgnoreError: isIgnorableError([]string{"403"}),
+			Hydrate:       listKeyDetails,
+			ParentHydrate: listKeyRingDetails,
 			KeyColumns: plugin.KeyColumnSlice{
 				// String columns
 				{Name: "purpose", Require: plugin.Optional, Operators: []string{"<>", "="}},

--- a/gcp/table_gcp_kms_key_ring.go
+++ b/gcp/table_gcp_kms_key_ring.go
@@ -22,8 +22,7 @@ func tableGcpKmsKeyRing(ctx context.Context) *plugin.Table {
 			Hydrate:    getKeyRingDetail,
 		},
 		List: &plugin.ListConfig{
-			Hydrate:           listKeyRingDetails,
-			ShouldIgnoreError: isIgnorableError([]string{"403"}),
+			Hydrate: listKeyRingDetails,
 		},
 		GetMatrixItemFunc: BuildLocationList,
 		Columns: []*plugin.Column{

--- a/gcp/table_gcp_kms_key_version.go
+++ b/gcp/table_gcp_kms_key_version.go
@@ -24,9 +24,8 @@ func tableGcpKmsKeyVersion(ctx context.Context) *plugin.Table {
 			Hydrate:    getKeyVersionDetail,
 		},
 		List: &plugin.ListConfig{
-			Hydrate:           listKeyVersionDetails,
-			ParentHydrate:     listKeyRingDetails,
-			ShouldIgnoreError: isIgnorableError([]string{"403"}),
+			Hydrate:       listKeyVersionDetails,
+			ParentHydrate: listKeyRingDetails,
 		},
 		GetMatrixItemFunc: BuildLocationList,
 		Columns: []*plugin.Column{

--- a/gcp/table_gcp_kubernetes_cluster.go
+++ b/gcp/table_gcp_kubernetes_cluster.go
@@ -17,8 +17,7 @@ func tableGcpKubernetesCluster(ctx context.Context) *plugin.Table {
 		Name:        "gcp_kubernetes_cluster",
 		Description: "GCP Kubernetes Cluster",
 		List: &plugin.ListConfig{
-			Hydrate:           listKubernetesClusters,
-			ShouldIgnoreError: isIgnorableError([]string{"403"}),
+			Hydrate: listKubernetesClusters,
 		},
 		Get: &plugin.GetConfig{
 			KeyColumns: plugin.AllColumns([]string{"name", "location"}),

--- a/gcp/table_gcp_kubernetes_node_pool.go
+++ b/gcp/table_gcp_kubernetes_node_pool.go
@@ -17,9 +17,8 @@ func tableGcpKubernetesNodePool(ctx context.Context) *plugin.Table {
 		Name:        "gcp_kubernetes_node_pool",
 		Description: "GCP Kubernetes Node Pool",
 		List: &plugin.ListConfig{
-			Hydrate:           listKubernetesNodePools,
-			ParentHydrate:     listKubernetesClusters,
-			ShouldIgnoreError: isIgnorableError([]string{"403"}),
+			Hydrate:       listKubernetesNodePools,
+			ParentHydrate: listKubernetesClusters,
 		},
 		Get: &plugin.GetConfig{
 			KeyColumns: plugin.AllColumns([]string{"name", "location", "cluster_name"}),

--- a/gcp/table_gcp_logging_bucket.go
+++ b/gcp/table_gcp_logging_bucket.go
@@ -23,8 +23,7 @@ func tableGcpLoggingBucket(_ context.Context) *plugin.Table {
 			Hydrate:    getLoggingBucket,
 		},
 		List: &plugin.ListConfig{
-			Hydrate:           listLoggingBuckets,
-			ShouldIgnoreError: isIgnorableError([]string{"403"}),
+			Hydrate: listLoggingBuckets,
 		},
 		Columns: []*plugin.Column{
 			{

--- a/gcp/table_gcp_logging_exclusion.go
+++ b/gcp/table_gcp_logging_exclusion.go
@@ -22,8 +22,7 @@ func tableGcpLoggingExclusion(_ context.Context) *plugin.Table {
 			Hydrate:    getGcpLoggingExclusion,
 		},
 		List: &plugin.ListConfig{
-			Hydrate:           listGcpLoggingExclusions,
-			ShouldIgnoreError: isIgnorableError([]string{"403"}),
+			Hydrate: listGcpLoggingExclusions,
 		},
 		Columns: []*plugin.Column{
 			{

--- a/gcp/table_gcp_logging_metric.go
+++ b/gcp/table_gcp_logging_metric.go
@@ -22,8 +22,7 @@ func tableGcpLoggingMetric(_ context.Context) *plugin.Table {
 			Hydrate:    getGcpLoggingMetric,
 		},
 		List: &plugin.ListConfig{
-			Hydrate:           listGcpLoggingMetrics,
-			ShouldIgnoreError: isIgnorableError([]string{"403"}),
+			Hydrate: listGcpLoggingMetrics,
 		},
 		Columns: []*plugin.Column{
 			{

--- a/gcp/table_gcp_logging_sink.go
+++ b/gcp/table_gcp_logging_sink.go
@@ -22,8 +22,7 @@ func tableGcpLoggingSink(_ context.Context) *plugin.Table {
 			Hydrate:    getGcpLoggingSink,
 		},
 		List: &plugin.ListConfig{
-			Hydrate:           listGcpLoggingSinks,
-			ShouldIgnoreError: isIgnorableError([]string{"403"}),
+			Hydrate: listGcpLoggingSinks,
 		},
 		Columns: []*plugin.Column{
 			{

--- a/gcp/table_gcp_monitoring_alert_policy.go
+++ b/gcp/table_gcp_monitoring_alert_policy.go
@@ -20,8 +20,7 @@ func tableGcpMonitoringAlert(_ context.Context) *plugin.Table {
 			Hydrate:    getMonitoringAlertPolicy,
 		},
 		List: &plugin.ListConfig{
-			Hydrate:           listMonitoringAlertPolicies,
-			ShouldIgnoreError: isIgnorableError([]string{"403"}),
+			Hydrate: listMonitoringAlertPolicies,
 			KeyColumns: plugin.KeyColumnSlice{
 				// String columns
 				{Name: "display_name", Require: plugin.Optional, Operators: []string{"<>", "="}},

--- a/gcp/table_gcp_monitoring_group.go
+++ b/gcp/table_gcp_monitoring_group.go
@@ -20,8 +20,7 @@ func tableGcpMonitoringGroup(_ context.Context) *plugin.Table {
 			Hydrate:    getMonitoringGroup,
 		},
 		List: &plugin.ListConfig{
-			Hydrate:           listMonitoringGroup,
-			ShouldIgnoreError: isIgnorableError([]string{"403"}),
+			Hydrate: listMonitoringGroup,
 		},
 		Columns: []*plugin.Column{
 			{

--- a/gcp/table_gcp_monitoring_notification_channel.go
+++ b/gcp/table_gcp_monitoring_notification_channel.go
@@ -23,8 +23,7 @@ func tableGcpMonitoringNotificationChannel(_ context.Context) *plugin.Table {
 			Hydrate:    getGcpMonitoringNotificationChannel,
 		},
 		List: &plugin.ListConfig{
-			Hydrate:           listGcpMonitoringNotificationChannels,
-			ShouldIgnoreError: isIgnorableError([]string{"403"}),
+			Hydrate: listGcpMonitoringNotificationChannels,
 			KeyColumns: plugin.KeyColumnSlice{
 				// String columns
 				{Name: "type", Require: plugin.Optional, Operators: []string{"<>", "="}},

--- a/gcp/table_gcp_organization.go
+++ b/gcp/table_gcp_organization.go
@@ -19,8 +19,7 @@ func tableGcpOrganization(_ context.Context) *plugin.Table {
 		Name:        "gcp_organization",
 		Description: "GCP Organization",
 		List: &plugin.ListConfig{
-			Hydrate:           listGCPOrganizations,
-			ShouldIgnoreError: isIgnorableError([]string{"403"}),
+			Hydrate: listGCPOrganizations,
 		},
 		Columns: []*plugin.Column{
 			{

--- a/gcp/table_gcp_project.go
+++ b/gcp/table_gcp_project.go
@@ -17,8 +17,7 @@ func tableGcpProject(_ context.Context) *plugin.Table {
 		Name:        "gcp_project",
 		Description: "GCP Project",
 		List: &plugin.ListConfig{
-			Hydrate:           listGCPProjects,
-			ShouldIgnoreError: isIgnorableError([]string{"403"}),
+			Hydrate: listGCPProjects,
 		},
 		Columns: []*plugin.Column{
 			{

--- a/gcp/table_gcp_project_organization_policy.go
+++ b/gcp/table_gcp_project_organization_policy.go
@@ -22,8 +22,7 @@ func tableGcpProjectOrganizationPolicy(ctx context.Context) *plugin.Table {
 			Hydrate:    getProjectOrganizationPolicy,
 		},
 		List: &plugin.ListConfig{
-			Hydrate:           listProjectOrganizationPolicies,
-			ShouldIgnoreError: isIgnorableError([]string{"403"}),
+			Hydrate: listProjectOrganizationPolicies,
 		},
 		Columns: []*plugin.Column{
 			{

--- a/gcp/table_gcp_project_service.go
+++ b/gcp/table_gcp_project_service.go
@@ -20,11 +20,10 @@ func tableGcpProjectService(_ context.Context) *plugin.Table {
 		Get: &plugin.GetConfig{
 			KeyColumns:        plugin.SingleColumn("name"),
 			Hydrate:           getGcpProjectService,
-			ShouldIgnoreError: isIgnorableError([]string{"404", "403"}),
+			ShouldIgnoreError: isIgnorableError([]string{"404"}),
 		},
 		List: &plugin.ListConfig{
-			Hydrate:           listGcpProjectServices,
-			ShouldIgnoreError: isIgnorableError([]string{"403"}),
+			Hydrate: listGcpProjectServices,
 			KeyColumns: plugin.KeyColumnSlice{
 				// String columns
 				{Name: "state", Require: plugin.Optional, Operators: []string{"<>", "="}},

--- a/gcp/table_gcp_pubsub_snapshot.go
+++ b/gcp/table_gcp_pubsub_snapshot.go
@@ -21,8 +21,7 @@ func tableGcpPubSubSnapshot(ctx context.Context) *plugin.Table {
 			Hydrate:    getPubSubSnapshot,
 		},
 		List: &plugin.ListConfig{
-			Hydrate:           listPubSubSnapshots,
-			ShouldIgnoreError: isIgnorableError([]string{"403"}),
+			Hydrate: listPubSubSnapshots,
 		},
 		Columns: []*plugin.Column{
 			{

--- a/gcp/table_gcp_pubsub_subscription.go
+++ b/gcp/table_gcp_pubsub_subscription.go
@@ -21,8 +21,7 @@ func tableGcpPubSubSubscription(ctx context.Context) *plugin.Table {
 			Hydrate:    getPubSubSubscription,
 		},
 		List: &plugin.ListConfig{
-			Hydrate:           listPubSubSubscription,
-			ShouldIgnoreError: isIgnorableError([]string{"403"}),
+			Hydrate: listPubSubSubscription,
 		},
 		Columns: []*plugin.Column{
 			{

--- a/gcp/table_gcp_pubsub_topic.go
+++ b/gcp/table_gcp_pubsub_topic.go
@@ -21,8 +21,7 @@ func tableGcpPubSubTopic(ctx context.Context) *plugin.Table {
 			Hydrate:    getPubSubTopic,
 		},
 		List: &plugin.ListConfig{
-			Hydrate:           listPubSubTopics,
-			ShouldIgnoreError: isIgnorableError([]string{"403"}),
+			Hydrate: listPubSubTopics,
 		},
 		Columns: []*plugin.Column{
 			{

--- a/gcp/table_gcp_service_account.go
+++ b/gcp/table_gcp_service_account.go
@@ -22,8 +22,7 @@ func tableGcpServiceAccount(_ context.Context) *plugin.Table {
 			Hydrate:    getGcpServiceAccount,
 		},
 		List: &plugin.ListConfig{
-			Hydrate:           listGcpServiceAccounts,
-			ShouldIgnoreError: isIgnorableError([]string{"403"}),
+			Hydrate: listGcpServiceAccounts,
 		},
 		Columns: []*plugin.Column{
 			{

--- a/gcp/table_gcp_service_account_key.go
+++ b/gcp/table_gcp_service_account_key.go
@@ -21,9 +21,8 @@ func tableGcpServiceAccountKey(_ context.Context) *plugin.Table {
 			Hydrate:    getGcpServiceAccountKey,
 		},
 		List: &plugin.ListConfig{
-			ParentHydrate:     listGcpServiceAccounts,
-			Hydrate:           listGcpServiceAccountKeys,
-			ShouldIgnoreError: isIgnorableError([]string{"403"}),
+			ParentHydrate: listGcpServiceAccounts,
+			Hydrate:       listGcpServiceAccountKeys,
 		},
 		Columns: []*plugin.Column{
 			{

--- a/gcp/table_gcp_sql_backup.go
+++ b/gcp/table_gcp_sql_backup.go
@@ -23,9 +23,8 @@ func tableGcpSQLBackup(ctx context.Context) *plugin.Table {
 			Hydrate:    getSQLBackup,
 		},
 		List: &plugin.ListConfig{
-			Hydrate:           listSQLBackups,
-			ParentHydrate:     listSQLDatabaseInstances,
-			ShouldIgnoreError: isIgnorableError([]string{"403"}),
+			Hydrate:       listSQLBackups,
+			ParentHydrate: listSQLDatabaseInstances,
 		},
 		Columns: []*plugin.Column{
 			{

--- a/gcp/table_gcp_sql_database.go
+++ b/gcp/table_gcp_sql_database.go
@@ -27,9 +27,8 @@ func tableGcpSQLDatabase(ctx context.Context) *plugin.Table {
 			Hydrate:    getSQLDatabase,
 		},
 		List: &plugin.ListConfig{
-			Hydrate:           listSQLDatabases,
-			ParentHydrate:     listSQLDatabaseInstances,
-			ShouldIgnoreError: isIgnorableError([]string{"403"}),
+			Hydrate:       listSQLDatabases,
+			ParentHydrate: listSQLDatabaseInstances,
 		},
 		Columns: []*plugin.Column{
 			{

--- a/gcp/table_gcp_sql_database_instance.go
+++ b/gcp/table_gcp_sql_database_instance.go
@@ -24,8 +24,7 @@ func tableGcpSQLDatabaseInstance(ctx context.Context) *plugin.Table {
 			Hydrate:    getSQLDatabaseInstance,
 		},
 		List: &plugin.ListConfig{
-			Hydrate:           listSQLDatabaseInstances,
-			ShouldIgnoreError: isIgnorableError([]string{"403"}),
+			Hydrate: listSQLDatabaseInstances,
 			KeyColumns: plugin.KeyColumnSlice{
 				// String columns
 				{Name: "instance_type", Require: plugin.Optional, Operators: []string{"<>", "="}},

--- a/gcp/table_gcp_sql_database_instance_metric_connections.go
+++ b/gcp/table_gcp_sql_database_instance_metric_connections.go
@@ -16,9 +16,8 @@ func tableGcpSQLDatabaseInstanceMetricConnections(_ context.Context) *plugin.Tab
 		Name:        "gcp_sql_database_instance_metric_connections",
 		Description: "GCP SQL Database Instance Metrics Connections",
 		List: &plugin.ListConfig{
-			ParentHydrate:     listSQLDatabaseInstances,
-			Hydrate:           listSQLDatabaseInstanceMetricConnections,
-			ShouldIgnoreError: isIgnorableError([]string{"403"}),
+			ParentHydrate: listSQLDatabaseInstances,
+			Hydrate:       listSQLDatabaseInstanceMetricConnections,
 		},
 		Columns: monitoringMetricColumns([]*plugin.Column{
 			{

--- a/gcp/table_gcp_sql_database_instance_metric_connections_daily.go
+++ b/gcp/table_gcp_sql_database_instance_metric_connections_daily.go
@@ -16,9 +16,8 @@ func tableGcpSQLDatabaseInstanceMetricConnectionsDaily(_ context.Context) *plugi
 		Name:        "gcp_sql_database_instance_metric_connections_daily",
 		Description: "GCP SQL Database Instance Metrics - Connections (Daily)",
 		List: &plugin.ListConfig{
-			ParentHydrate:     listSQLDatabaseInstances,
-			Hydrate:           listSQLDatabaseInstanceMetricConnectionsDaily,
-			ShouldIgnoreError: isIgnorableError([]string{"403"}),
+			ParentHydrate: listSQLDatabaseInstances,
+			Hydrate:       listSQLDatabaseInstanceMetricConnectionsDaily,
 		},
 		Columns: monitoringMetricColumns([]*plugin.Column{
 			{

--- a/gcp/table_gcp_sql_database_instance_metric_connections_hourly.go
+++ b/gcp/table_gcp_sql_database_instance_metric_connections_hourly.go
@@ -16,9 +16,8 @@ func tableGcpSQLDatabaseInstanceMetricConnectionsHourly(_ context.Context) *plug
 		Name:        "gcp_sql_database_instance_metric_connections_hourly",
 		Description: "GCP SQL Database Instance Metrics - Connections (Hourly)",
 		List: &plugin.ListConfig{
-			ParentHydrate:     listSQLDatabaseInstances,
-			Hydrate:           listSQLDatabaseInstanceMetricConnectionsHourly,
-			ShouldIgnoreError: isIgnorableError([]string{"403"}),
+			ParentHydrate: listSQLDatabaseInstances,
+			Hydrate:       listSQLDatabaseInstanceMetricConnectionsHourly,
 		},
 		Columns: monitoringMetricColumns([]*plugin.Column{
 			{

--- a/gcp/table_gcp_sql_database_instance_metric_cpu_utilization.go
+++ b/gcp/table_gcp_sql_database_instance_metric_cpu_utilization.go
@@ -16,9 +16,8 @@ func tableGcpSQLDatabaseInstanceMetricCpuUtilization(_ context.Context) *plugin.
 		Name:        "gcp_sql_database_instance_metric_cpu_utilization",
 		Description: "GCP SQL Database Instance Metrics - CPU Utilization",
 		List: &plugin.ListConfig{
-			ParentHydrate:     listSQLDatabaseInstances,
-			Hydrate:           listSQLDatabaseInstanceMetricCpuUtilization,
-			ShouldIgnoreError: isIgnorableError([]string{"403"}),
+			ParentHydrate: listSQLDatabaseInstances,
+			Hydrate:       listSQLDatabaseInstanceMetricCpuUtilization,
 		},
 		Columns: monitoringMetricColumns([]*plugin.Column{
 			{

--- a/gcp/table_gcp_sql_database_instance_metric_cpu_utilization_daily.go
+++ b/gcp/table_gcp_sql_database_instance_metric_cpu_utilization_daily.go
@@ -16,9 +16,8 @@ func tableGcpSQLDatabaseInstanceMetricCpuUtilizationDaily(_ context.Context) *pl
 		Name:        "gcp_sql_database_instance_metric_cpu_utilization_daily",
 		Description: "GCP SQL Database Instance Metrics - CPU Utilization (Daily)",
 		List: &plugin.ListConfig{
-			ParentHydrate:     listSQLDatabaseInstances,
-			Hydrate:           listSQLDatabaseInstanceMetricCpuUtilizationDaily,
-			ShouldIgnoreError: isIgnorableError([]string{"403"}),
+			ParentHydrate: listSQLDatabaseInstances,
+			Hydrate:       listSQLDatabaseInstanceMetricCpuUtilizationDaily,
 		},
 		Columns: monitoringMetricColumns([]*plugin.Column{
 			{

--- a/gcp/table_gcp_sql_database_instance_metric_cpu_utilization_hourly.go
+++ b/gcp/table_gcp_sql_database_instance_metric_cpu_utilization_hourly.go
@@ -16,9 +16,8 @@ func tableGcpSQLDatabaseInstanceMetricCpuUtilizationHourly(_ context.Context) *p
 		Name:        "gcp_sql_database_instance_metric_cpu_utilization_hourly",
 		Description: "GCP SQL Database Instance Metrics - CPU Utilization (Hourly)",
 		List: &plugin.ListConfig{
-			ParentHydrate:     listSQLDatabaseInstances,
-			Hydrate:           listSQLDatabaseInstanceMetricCpuUtilizationHourly,
-			ShouldIgnoreError: isIgnorableError([]string{"403"}),
+			ParentHydrate: listSQLDatabaseInstances,
+			Hydrate:       listSQLDatabaseInstanceMetricCpuUtilizationHourly,
 		},
 		Columns: monitoringMetricColumns([]*plugin.Column{
 			{

--- a/gcp/table_gcp_storage_bucket.go
+++ b/gcp/table_gcp_storage_bucket.go
@@ -20,8 +20,7 @@ func tableGcpStorageBucket(_ context.Context) *plugin.Table {
 			Hydrate:    getGcpStorageBucket,
 		},
 		List: &plugin.ListConfig{
-			Hydrate:           listGcpStorageBuckets,
-			ShouldIgnoreError: isIgnorableError([]string{"403"}),
+			Hydrate: listGcpStorageBuckets,
 		},
 		Columns: []*plugin.Column{
 			{


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
N/A
```
</details>

# Example query results
<details>
  <summary>Results</summary>

1. ~/.steampipe/config/gcp.spc  (**without** `ignore_error_codes` configuration)
2. `sqladmin.googleapis.com` API disabled
```
connection "gcp" {
  plugin    = "gcp"
  project = "YOUR_PROJECT_NAME"
  credentials = "~/.config/gcloud/application_default_credentials.json"
}
```

Query result for table `gcp_sql_database`

```
> select * from gcp_sql_database
Error: googleapi: Error 403: Cloud SQL Admin API has not been used in project 123456785634 before or it is disabled. Enable it by visiting https://console.developers.google.com/apis/api/sqladmin.googleapis.com/overview?project=123456785634 then retry. If you enabled this API recently, wait a few minutes for the action to propagate to our systems and retry.
Details:
[
  {
    "@type": "type.googleapis.com/google.rpc.Help",
    "links": [
      {
        "description": "Google developers console API activation",
        "url": "https://console.developers.google.com/apis/api/sqladmin.googleapis.com/overview?project=123456785634"
      }
    ]
  },
  {
    "@type": "type.googleapis.com/google.rpc.ErrorInfo",
    "domain": "googleapis.com",
    "metadata": {
      "consumer": "projects/123456785634",
      "service": "sqladmin.googleapis.com"
    },
    "reason": "SERVICE_DISABLED"
  }
]
, accessNotConfigured (SQLSTATE HV000)
```
#
1. ~/.steampipe/config/gcp.spc  (**with** `ignore_error_codes` configuration)
2. `sqladmin.googleapis.com` API disabled
```
connection "gcp" {
  plugin    = "gcp"
  project = "YOUR_PROJECT_NAME"
  credentials = "~/.config/gcloud/application_default_credentials.json"
  ignore_error_codes = ["403"]
}
```

Query result for table `gcp_sql_database`

```
> select * from gcp_sql_database
+------+---------------+------+---------+-----------+-----------+-----------------------------------------+------------------------------------+-------+------+----------+---------+------+
| name | instance_name | kind | charset | collation | self_link | sql_server_database_compatibility_level | sql_server_database_recovery_model | title | akas | location | project | _ctx |
+------+---------------+------+---------+-----------+-----------+-----------------------------------------+------------------------------------+-------+------+----------+---------+------+
+------+---------------+------+---------+-----------+-----------+-----------------------------------------+------------------------------------+-------+------+----------+---------+------+

```

</details>
