### PR TITLE
listGCPProjects failed with panic runtime error #385

### DIFF
--- a/gcp/table_gcp_project.go
+++ b/gcp/table_gcp_project.go
@@ -106,21 +106,20 @@ func listGCPProjects(ctx context.Context, d *plugin.QueryData, h *plugin.Hydrate
 	}
 
 	// Get project details
-	getProjectCached := plugin.HydrateFunc(getProject).WithCache()
-	projectId, err := getProjectCached(ctx, d, h)
+	//getProjectCached := plugin.HydrateFunc(getProject).WithCache()
+	//projectId, err := getProjectCached(ctx, d, h)
+	//if err != nil {
+	//	return nil, err
+	//}
+	// project := projectId.(string)
+
+	resp, err := service.Projects.List().Do()
 	if err != nil {
 		return nil, err
 	}
-	project := projectId.(string)
-
-	resp, err := service.Projects.List().Filter("id=" + project).Do()
 	for _, project := range resp.Projects {
 		d.StreamListItem(ctx, project)
 	}
-	if err != nil {
-		return nil, err
-	}
-
 	return nil, nil
 }
 
@@ -159,6 +158,9 @@ func getProjectAccessApprovalSettings(ctx context.Context, d *plugin.QueryData, 
 	resp, err := service.Projects.GetAccessApprovalSettings("projects/" + project + "/accessApprovalSettings").Do()
 	if err != nil {
 		if strings.Contains(err.Error(), "404") {
+			return nil, nil
+		}
+		if strings.Contains(err.Error(), "403") {
 			return nil, nil
 		}
 		plugin.Logger(ctx).Error("gcp_project.getProjectAccessApprovalSettings", "api_err", err)


### PR DESCRIPTION
First attempt to fix the error:

    hydrate function listGCPProjects failed with panic runtime error:
    invalid memory address or nil pointer dereference

It seems related to use an invalid filter.

# Integration test logs
<details>
  <summary>Logs</summary>
  
```
Add passing integration test logs here
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
Add example SQL query results here (please include the input queries as well)
```
</details>
