### PR TITLE
feat(gcp_storage_object): add prefix filter to storage object list 

### DIFF
--- a/docs/tables/gcp_storage_object.md
+++ b/docs/tables/gcp_storage_object.md
@@ -37,6 +37,23 @@ where
   and name = 'test/logs/2021/03/01/12/abc.txt';
 ```
 
+### List storage objects with a prefix in a bucket
+
+```sql
+select
+  id,
+  name,
+  bucket,
+  size,
+  storage_class,
+  time_created
+from
+  gcp_storage_object
+where
+  bucket = 'steampipe-test'
+  and prefix = 'test/logs/2021/03/01/12';
+```
+
 ### List storage objects encrypted with customer managed keys
 
 ```sql


### PR DESCRIPTION
add prefix filter to storage object list 

# Integration test logs
<details>
  <summary>Logs</summary>
  
```
select
    name
from
    gcp_storage_object
where
    bucket = 'cdn-signature' and
    prefix = 'prefix'
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
prefix/items1.txt
prefix/items2.txt
```
</details>
