### PR TITLE
Fixed the table gcp_compute_machine_type not support t2a machine type query Closes #466

### DIFF
--- a/docs/tables/gcp_compute_machine_type.md
+++ b/docs/tables/gcp_compute_machine_type.md
@@ -69,7 +69,7 @@ from
 select
   name,
   zone,
-  count(name) as number_of_machine_type
+  count(name) as numbers_of_machine_type
 from
   gcp_compute_machine_type
 group by

--- a/docs/tables/gcp_compute_machine_type.md
+++ b/docs/tables/gcp_compute_machine_type.md
@@ -62,3 +62,17 @@ from
   gcp_compute_machine_type,
   jsonb_array_elements(accelerators) as a;
 ```
+
+### Display the categorization of machine types by zone
+
+```sql
+select
+  name,
+  zone,
+  count(name) as number_of_machine_type
+from
+  gcp_compute_machine_type
+group by
+  name,
+  zone;
+```

--- a/gcp-test/tests/gcp_compute_machine_type/test-get-query.sql
+++ b/gcp-test/tests/gcp_compute_machine_type/test-get-query.sql
@@ -1,3 +1,3 @@
 select name, title, akas, kind, guest_cpus, memory_mb, image_space_gb, maximum_persistent_disks, maximum_persistent_disks_size_gb, is_shared_cpu
 from gcp.gcp_compute_machine_type
-where name = '{{ output.machine_type.value }}';
+where name = '{{ output.machine_type.value }}' and zone = 'us-east1-b';

--- a/gcp-test/tests/gcp_compute_machine_type/test-list-query.sql
+++ b/gcp-test/tests/gcp_compute_machine_type/test-list-query.sql
@@ -1,3 +1,3 @@
 select name, title, akas
 from gcp.gcp_compute_machine_type
-where akas::text = '["{{ output.resource_aka.value }}"]';
+where akas::text = '["{{ output.resource_aka.value }}"]' and zone = 'us-east1-b';

--- a/gcp-test/tests/gcp_compute_machine_type/test-turbot-query.sql
+++ b/gcp-test/tests/gcp_compute_machine_type/test-turbot-query.sql
@@ -1,3 +1,3 @@
 select title, akas
 from gcp.gcp_compute_machine_type
-where name = '{{ output.machine_type.value }}';
+where name = '{{ output.machine_type.value }}' and zone = 'us-east1-b';

--- a/gcp-test/tests/gcp_compute_machine_type/variables.tf
+++ b/gcp-test/tests/gcp_compute_machine_type/variables.tf
@@ -41,7 +41,7 @@ output "machine_type" {
 }
 
 output "zone" {
-  value = "us-central1-c"
+  value = "us-east1-b"
 }
 
 output "resource_aka" {


### PR DESCRIPTION

# Integration test logs
<details>
  <summary>Logs</summary>
  
```
No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging
customEnv TURBOT_TEST_EXPECTED_TIMEOUT undefined

SETUP: tests/gcp_compute_machine_type []

PRETEST: tests/gcp_compute_machine_type

TEST: tests/gcp_compute_machine_type
Running terraform
data.google_client_config.current: Reading...
data.google_client_config.current: Read complete after 0s [id=projects/"absgd-qow"/regions/"us-east1"/zones/"us-east1-b"]
data.null_data_source.resource: Reading...
data.null_data_source.resource: Read complete after 0s [id=static]

No changes. Your infrastructure matches the configuration.

Terraform has compared your real infrastructure against your configuration
and found no differences, so no changes are needed.

Warning: Deprecated

  with data.null_data_source.resource,
  on variables.tf line 33, in data "null_data_source" "resource":
  33: data "null_data_source" "resource" {

The null_data_source was historically used to construct intermediate values
to re-use elsewhere in configuration, the same can now be achieved using
locals

(and one more similar warning elsewhere)

Apply complete! Resources: 0 added, 0 changed, 0 destroyed.

Outputs:

machine_type = "a2-highgpu-4g"
resource_aka = "gcp://compute.googleapis.com/projects/absgd-qow/machineTypes/a2-highgpu-4g"
zone = "us-east1-b"

Running SQL query: test-get-query.sql
[
  {
    "akas": [
      "gcp://compute.googleapis.com/projects/absgd-qow/machineTypes/a2-highgpu-4g"
    ],
    "guest_cpus": 48,
    "image_space_gb": 0,
    "is_shared_cpu": false,
    "kind": "compute#machineType",
    "maximum_persistent_disks": 128,
    "maximum_persistent_disks_size_gb": 263168,
    "memory_mb": 348160,
    "name": "a2-highgpu-4g",
    "title": "a2-highgpu-4g"
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "akas": [
      "gcp://compute.googleapis.com/projects/absgd-qow/machineTypes/a2-highgpu-4g"
    ],
    "name": "a2-highgpu-4g",
    "title": "a2-highgpu-4g"
  }
]
✔ PASSED

Running SQL query: test-notfound-query.sql
null
✔ PASSED

Running SQL query: test-turbot-query.sql
[
  {
    "akas": [
      "gcp://compute.googleapis.com/projects/absgd-qow/machineTypes/a2-highgpu-4g"
    ],
    "title": "a2-highgpu-4g"
  }
]
✔ PASSED

POSTTEST: tests/gcp_compute_machine_type

TEARDOWN: tests/gcp_compute_machine_type

SUMMARY:

1/1 passed.
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
> select * from gcp_compute_machine_type where zone = 'asia-southeast2-c'
+-----------------+--------+----------------------------------------------------------------------------------------------------------------+---------------------------+--------------------------------------------------------------------+------------+-----------+------>
| name            | id     | self_link                                                                                                      | creation_timestamp        | description                                                        | guest_cpus | memory_mb | image>
+-----------------+--------+----------------------------------------------------------------------------------------------------------------+---------------------------+--------------------------------------------------------------------+------------+-----------+------>
| e2-highmem-8    | 336008 | https://www.googleapis.com/compute/v1/projects/absgd-qow/zones/asia-southeast2-c/machineTypes/e2-highmem-8    | 1970-01-01T05:30:00+05:30 | Efficient Instance, 8 vCPUs, 64 GB RAM                             | 8          | 65536     | 0    >
| n2-standard-96  | 901096 | https://www.googleapis.com/compute/v1/projects/absgd-qow/zones/asia-southeast2-c/machineTypes/n2-standard-96  | 1970-01-01T05:30:00+05:30 | 96 vCPUs 384 GB RAM                                                | 96         | 393216    | 0    >
| m1-ultramem-160 | 11160  | https://www.googleapis.com/compute/v1/projects/absgd-qow/zones/asia-southeast2-c/machineTypes/m1-ultramem-160 | 1970-01-01T05:30:00+05:30 | 160 vCPUs, 3844 GB RAM                                             | 160        | 3936256   | 0    >
| e2-highcpu-2    | 337002 | https://www.googleapis.com/compute/v1/projects/absgd-qow/zones/asia-southeast2-c/machineTypes/e2-highcpu-2    | 1970-01-01T05:30:00+05:30 | Efficient Instance, 2 vCPUs, 2 GB RAM                              | 2          | 2048      | 0    >
| n2-highcpu-8    | 903008 | https://www.googleapis.com/compute/v1/projects/absgd-qow/zones/asia-southeast2-c/machineTypes/n2-highcpu-8    | 1970-01-01T05:30:00+05:30 | 8 vCPUs 8 GB RAM                                                   | 8          | 8192      | 0    >
| e2-highcpu-32   | 337032 | https://www.googleapis.com/compute/v1/projects/absgd-qow/zones/asia-southeast2-c/machineTypes/e2-highcpu-32   | 1970-01-01T05:30:00+05:30 | Efficient Instance, 32 vCPUs, 32 GB RAM                            | 32         | 32768     | 0    >
| f1-micro        | 1000   | https://www.googleapis.com/compute/v1/projects/absgd-qow/zones/asia-southeast2-c/machineTypes/f1-micro        | 1970-01-01T05:30:00+05:30 | 1 vCPU (shared physical core) and 0.6 GB RAM                       | 1          | 614       | 0    >
| n2-highcpu-80   | 903080 | https://www.googleapis.com/compute/v1/projects/absgd-qow/zones/asia-southeast2-c/machineTypes/n2-highcpu-80   | 1970-01-01T05:30:00+05:30 | 80 vCPUs 80 GB RAM                                                 | 80         | 81920     | 0    >
| g1-small        | 2000   | https://www.googleapis.com/compute/v1/projects/absgd-qow/zones/asia-southeast2-c/machineTypes/g1-small        | 1970-01-01T05:30:00+05:30 | 1 vCPU (shared physical core) and 1.7 GB RAM                       | 1          | 1740      | 0    >
| e2-highcpu-4    | 337004 | https://www.googleapis.com/compute/v1/projects/absgd-qow/zones/asia-southeast2-c/machineTypes/e2-highcpu-4    | 1970-01-01T05:30:00+05:30 | Efficient Instance, 4 vCPUs, 4 GB RAM                              | 4          | 4096      | 0    >
| n2-highcpu-96   | 903096 | https://www.googleapis.com/compute/v1/projects/absgd-qow/zones/asia-southeast2-c/machineTypes/n2-highcpu-96   | 1970-01-01T05:30:00+05:30 | 96 vCPUs 96 GB RAM                                                 | 96         | 98304     | 0    >
| m1-megamem-96   | 9196   | https://www.googleapis.com/compute/v1/projects/absgd-qow/zones/asia-southeast2-c/machineTypes/m1-megamem-96   | 1970-01-01T05:30:00+05:30 | 96 vCPUs, 1.4 TB RAM                                               | 96         | 1468006   | 0    >
| e2-standard-8   | 335008 | https://www.googleapis.com/compute/v1/projects/absgd-qow/zones/asia-southeast2-c/machineTypes/e2-standard-8   | 1970-01-01T05:30:00+05:30 | Efficient Instance, 8 vCPUs, 32 GB RAM                             | 8          | 32768     | 0    >
| n2-highmem-128  | 902128 | https://www.googleapis.com/compute/v1/projects/absgd-qow/zones/asia-southeast2-c/machineTypes/n2-highmem-128  | 1970-01-01T05:30:00+05:30 | 128 vCPUs 864 GB RAM                                               | 128        | 884736    | 0  


> select * from gcp_compute_machine_type where zone = 'asia-southeast2-c' and name = 'n1-highcpu-32'
+---------------+------+--------------------------------------------------------------------------------------------------------------+---------------------------+-----------------------+------------+-----------+----------------+--------------------------+------------->
| name          | id   | self_link                                                                                                    | creation_timestamp        | description           | guest_cpus | memory_mb | image_space_gb | maximum_persistent_disks | maximum_pers>
+---------------+------+--------------------------------------------------------------------------------------------------------------+---------------------------+-----------------------+------------+-----------+----------------+--------------------------+------------->
| n1-highcpu-32 | 4032 | https://www.googleapis.com/compute/v1/projects/absgd-qow/zones/asia-southeast2-c/machineTypes/n1-highcpu-32 | 1970-01-01T05:30:00+05:30 | 32 vCPUs, 28.8 GB RAM | 32         | 29491     | 0              | 128                      | 263168      >
+---------------+------+--------------------------------------------------------------------------------------------------------------+---------------------------+-----------------------+------------+-----------+----------------+--------------------------+------------->

```
</details>
