### PR TITLE
IsLocked parameter not coming in cloumn retention_policy in table gcp_storage_bucket closes #501

### DIFF
--- a/gcp/table_gcp_storage_bucket.go
+++ b/gcp/table_gcp_storage_bucket.go
@@ -348,8 +348,7 @@ func extractRetentionPolicy(ctx context.Context, d *plugin.QueryData, h *plugin.
 		bucketRetentionPolicy["is_locked"] = bucket.RetentionPolicy.IsLocked
 
 		bucketRetentionPolicy["retention_period"] = bucket.RetentionPolicy.RetentionPeriod
-		// bucketRetentionPolicy["retention_period"] = strconv.FormatInt(bucket.RetentionPolicy.RetentionPeriod, 10)
-
+		
 		bucketRetentionPolicy["effective_time"] = bucket.RetentionPolicy.EffectiveTime
 	}
 

--- a/gcp/table_gcp_storage_bucket.go
+++ b/gcp/table_gcp_storage_bucket.go
@@ -196,6 +196,8 @@ func tableGcpStorageBucket(_ context.Context) *plugin.Table {
 				Name:        "retention_policy",
 				Description: "The bucket's retention policy. The retention policy enforces a minimum retention time for all objects contained in the bucket, based on their creation time. Any attempt to overwrite or delete objects younger than the retention period will result in a PERMISSION_DENIED error.",
 				Type:        proto.ColumnType_JSON,
+				Hydrate:     extractRetentionPolicy,
+				Transform:   transform.FromValue(),
 			},
 
 			// standard steampipe columns
@@ -298,7 +300,6 @@ func getGcpStorageBucket(ctx context.Context, d *plugin.QueryData, h *plugin.Hyd
 		plugin.Logger(ctx).Trace("getGcpStorageBucket", "Error", err)
 		return nil, err
 	}
-
 	return req, nil
 }
 
@@ -335,4 +336,22 @@ func getBucketAka(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateDat
 
 	akas := []string{"gcp://storage.googleapis.com/projects/" + project + "/buckets/" + bucket.Name}
 	return akas, nil
+}
+
+func extractRetentionPolicy(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+	bucket := h.Item.(*storage.Bucket)
+
+	bucketRetentionPolicy := make(map[string]interface{})
+
+	if bucket.RetentionPolicy != nil {
+
+		bucketRetentionPolicy["is_locked"] = bucket.RetentionPolicy.IsLocked
+
+		bucketRetentionPolicy["retention_period"] = bucket.RetentionPolicy.RetentionPeriod
+		// bucketRetentionPolicy["retention_period"] = strconv.FormatInt(bucket.RetentionPolicy.RetentionPeriod, 10)
+
+		bucketRetentionPolicy["effective_time"] = bucket.RetentionPolicy.EffectiveTime
+	}
+
+	return bucketRetentionPolicy, nil
 }


### PR DESCRIPTION

# Integration test logs
<details>
  <summary>Logs</summary>
  
```
NA
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
> select name, retention_policy from gcp_storage_bucket limit 1
+--------------------+----------------------------------------------------------------------------------------+
| name               | retention_policy                                                                       |
+--------------------+----------------------------------------------------------------------------------------+
| bucket-for-test-mr | {"effective_time":"2023-10-10T11:47:58.808Z","is_locked":false,"retention_period":100} |
+--------------------+----------------------------------------------------------------------------------------+
> 
```
</details>
