### PR TITLE
Add iam_policy in table gcp_cloud_run_service Closes #529

### DIFF
--- a/docs/tables/gcp_cloud_run_service.md
+++ b/docs/tables/gcp_cloud_run_service.md
@@ -197,6 +197,31 @@ from
   json_each(conditions) as c;
 ```
 
+### Get associated members or principals, with a role of services
+Attaching an Identity and Access Management (IAM) policy to a Google Cloud Run service involves setting permissions for that particular service. Google Cloud Run services use IAM for access control, and by configuring IAM policies, you can define who has what type of access to your Cloud Run services.
+
+```sql+postgres
+select
+  name,
+  i -> 'Condition' as condition,
+  i -> 'Members' as members,
+  i ->> 'Role' as role
+from
+  gcp_cloud_run_service,
+  jsonb_array_elements(iam_policy -> 'Bindings') as i;
+```
+
+```sql+sqlite
+select
+  name,
+  json_extract(i.value, '$.Condition') as condition,
+  json_extract(i.value, '$.Members') as members,
+  json_extract(i.value, '$.Role') as role
+from
+  gcp_cloud_run_service,
+  json_each(json_extract(iam_policy, '$.Bindings')) as i;
+```
+
 ### Get template details of services
 Explore the various attributes of your cloud-based services, such as encryption keys, container details, and scaling parameters. This query is useful to gain an understanding of your service configurations and identify areas for potential adjustments or enhancements.
 


### PR DESCRIPTION
Note: The result that we steampipe is returning is the same as the Gcloud CLI command(`gcloud run services get-iam-policy --region=us-central1 hello`) response.

# Integration test logs
<details>
  <summary>Logs</summary>
  
```
N/A
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
> select name, iam_policy from gcp_cloud_run_service
+-------+-----------------+
| name  | iam_policy      |
+-------+-----------------+
| hello | {"etag":"ACAB"} |
+-------+-----------------+

```
</details>
