### PR TITLE
Added null check for all the timestamp columns for the table gcp_sql_backup Closes #535

### DIFF
--- a/gcp/table_gcp_sql_backup.go
+++ b/gcp/table_gcp_sql_backup.go
@@ -63,16 +63,19 @@ func tableGcpSQLBackup(ctx context.Context) *plugin.Table {
 				Name:        "enqueued_time",
 				Description: "Specifies the time when the run was enqueued.",
 				Type:        proto.ColumnType_TIMESTAMP,
+				Transform:   transform.FromField("EnqueuedTime").NullIfZero(),
 			},
 			{
 				Name:        "start_time",
 				Description: "Specifies the time when the backup operation actually started.",
 				Type:        proto.ColumnType_TIMESTAMP,
+				Transform:   transform.FromField("StartTime").NullIfZero(),
 			},
 			{
 				Name:        "window_start_time",
 				Description: "Specifies the start time of the backup window during which this the backup was attempted.",
 				Type:        proto.ColumnType_TIMESTAMP,
+				Transform:   transform.FromField("WindowStartTime").NullIfZero(),
 			},
 			{
 				Name:        "self_link",


### PR DESCRIPTION

# Integration test logs
<details>
  <summary>Logs</summary>
  
```
No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging
customEnv TURBOT_TEST_EXPECTED_TIMEOUT undefined

SETUP: tests/gcp_sql_backup []

PRETEST: tests/gcp_sql_backup

TEST: tests/gcp_sql_backup
Running terraform
data.google_client_config.current: Reading...
google_sql_database_instance.named_test_resource: Refreshing state... [id=turbottest68934]
data.google_client_config.current: Read complete after 0s [id=projects/"parker-aaa"/regions/"us-east1"/zones/"us-east1-b"]
data.null_data_source.resource: Reading...
data.null_data_source.resource: Read complete after 0s [id=static]

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create
-/+ destroy and then create replacement
 <= read (data resources)

Terraform will perform the following actions:

  # data.local_file.input will be read during apply
  # (depends on a resource or a module with changes pending)
 <= data "local_file" "input" {
      + content              = (known after apply)
      + content_base64       = (known after apply)
      + content_base64sha256 = (known after apply)
      + content_base64sha512 = (known after apply)
      + content_md5          = (known after apply)
      + content_sha1         = (known after apply)
      + content_sha256       = (known after apply)
      + content_sha512       = (known after apply)
      + filename             = "/private/var/folders/v1/slpk6xvx5977gdtb0j_397kc0000gn/T/tests/gcp_sql_backup/terraform/test/output.json"
      + id                   = (known after apply)
    }

  # google_sql_database_instance.named_test_resource must be replaced
-/+ resource "google_sql_database_instance" "named_test_resource" {
      ~ available_maintenance_versions = [] -> (known after apply)
      ~ connection_name                = "parker-aaa:us-east1:turbottest68934" -> (known after apply)
      + dns_name                       = (known after apply)
      + encryption_key_name            = (known after apply)
      ~ first_ip_address               = "34.75.86.9" -> (known after apply)
      ~ id                             = "turbottest68934" -> (known after apply)
      ~ instance_type                  = "CLOUD_SQL_INSTANCE" -> (known after apply)
      ~ ip_address                     = [
          - {
              - ip_address     = "34.75.86.9"
              - time_to_retire = ""
              - type           = "PRIMARY"
            },
        ] -> (known after apply)
      ~ maintenance_version            = "MYSQL_5_6_51.R20231105.01_03" -> (known after apply)
      + master_instance_name           = (known after apply)
      ~ name                           = "turbottest68934" -> "turbottest87532" # forces replacement
      + private_ip_address             = (known after apply)
      + psc_service_attachment_link    = (known after apply)
      ~ public_ip_address              = "34.75.86.9" -> (known after apply)
      ~ self_link                      = "https://sqladmin.googleapis.com/sql/v1beta4/projects/parker-aaa/instances/turbottest68934" -> (known after apply)
      ~ server_ca_cert                 = [
          - {
              - cert             = <<-EOT
                    -----BEGIN CERTIFICATE-----
                    MIIDfzCCAmegAwIBAgIBADANBgkqhkiG9w0BAQsFADB3MS0wKwYDVQQuEyRiMDEx
                    ZWQxYi0yY2Q5LTRlYjQtOGMwZi05NTcxZGI5MzJlZTkxIzAhBgNVBAMTGkdvb2ds
                    ZSBDbG91ZCBTUUwgU2VydmVyIENBMRQwEgYDVQQKEwtHb29nbGUsIEluYzELMAkG
                    A1UEBhMCVVMwHhcNMjQwMTExMDQ0NzQzWhcNMzQwMTA4MDQ0ODQzWjB3MS0wKwYD
                    VQQuEyRiMDExZWQxYi0yY2Q5LTRlYjQtOGMwZi05NTcxZGI5MzJlZTkxIzAhBgNV
                    BAMTGkdvb2dsZSBDbG91ZCBTUUwgU2VydmVyIENBMRQwEgYDVQQKEwtHb29nbGUs
                    IEluYzELMAkGA1UEBhMCVVMwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIB
                    AQC5N7u9IR7+z4KkE3Xb0DhxwgGm4tIPRRXh89hixkCwMcA/cW2CzznfqlUjMbFd
                    9HEpkLcdWdn0qg4yYPpkrBS6wX260LU+vf+2k5/SUoCmw+BhHnXWFRQhcNTTP8Ab
                    wMqyo69Ia/IPb8XFh9gF5a7kNpMiQGtopTqE5Nhwtgeay8Uqz/Hw6/nHON9RzSNu
                    /6XiHs8ssSgkaVjnno95d6/DRZfJ2TifCgIciiwHrm9QzC4Adnfv4zqLHtLFYVad
                    Wd7MpYxRsI/qLFwRvUUmgPPCKn1G3i3y5UYK6We/2MMx7O+aIjbfkmqPQ4JrQY4X
                    +48Uv7t+zZKCW8bivkDZXyrnAgMBAAGjFjAUMBIGA1UdEwEB/wQIMAYBAf8CAQAw
                    DQYJKoZIhvcNAQELBQADggEBAGXhOT20R7Sgjm/M24TnkyStN/qX0YEuT9qiUQNP
                    9I5ei5NhAYlpRjvY4m0mJu0fSc+wDoxtzdNtkfOg7y+JulGHXe34h9Q6VoHKSPjE
                    Zp52uq7uZd19GiVbyrUt3leR1qQ0c6M/vuUHmNAF4TR1/xCFjj1n5U7o1/NZj+Lq
                    EZYGZ5GQ6okr1gbrkEbd+ThAr+iETIgFYNl1ZllGxURSKpKeSJ07fEbeAjm30gOb
                    PpWqqlvXD8V++G9qC68/PnVb8r85auomFKMM0JR3InJ1htgQ/SutvksXk+wVTkNy
                    r8w/Pc2aAerWJmHCpLpG2RaMsSOIgRtcmZ/KyCjfU1P2PAI=
                    -----END CERTIFICATE-----
                EOT
              - common_name      = "C=US,O=Google\\, Inc,CN=Google Cloud SQL Server CA,dnQualifier=b011ed1b-2cd9-4eb4-8c0f-9571db932ee9"
              - create_time      = "2024-01-11T04:47:43.318Z"
              - expiration_time  = "2034-01-08T04:48:43.318Z"
              - sha1_fingerprint = "7ee8fb6153cf7ebdee1af7148cd376ff30b54887"
            },
        ] -> (known after apply)
      ~ service_account_email_address  = "p979620418102-ni1257@gcp-sa-cloud-sql.iam.gserviceaccount.com" -> (known after apply)
        # (4 unchanged attributes hidden)

      ~ settings {
          ~ connector_enforcement       = "NOT_REQUIRED" -> (known after apply)
          - deletion_protection_enabled = false -> null
          ~ user_labels                 = {
              ~ "name" = "turbottest68934" -> "turbottest87532"
            }
          ~ version                     = 1 -> (known after apply)
            # (9 unchanged attributes hidden)

          ~ backup_configuration {
              - binary_log_enabled             = false -> null
              - point_in_time_recovery_enabled = false -> null
              ~ start_time                     = "06:00" -> (known after apply)
              ~ transaction_log_retention_days = 7 -> (known after apply)
                # (1 unchanged attribute hidden)

              - backup_retention_settings {
                  - retained_backups = 7 -> null
                  - retention_unit   = "COUNT" -> null
                }
            }

          - ip_configuration {
              - enable_private_path_for_google_cloud_services = false -> null
              - ipv4_enabled                                  = true -> null
              - require_ssl                                   = false -> null
            }

          - location_preference {
              - zone = "us-east1-c" -> null
            }
        }
    }

  # null_resource.list_resource will be created
  + resource "null_resource" "list_resource" {
      + id = (known after apply)
    }

  # null_resource.named_test_resource will be created
  + resource "null_resource" "named_test_resource" {
      + id = (known after apply)
    }

Plan: 3 to add, 0 to change, 1 to destroy.

Changes to Outputs:
  + backup_id     = (known after apply)
  ~ resource_name = "turbottest68934" -> "turbottest87532"
  + self_link     = (known after apply)
google_sql_database_instance.named_test_resource: Destroying... [id=turbottest68934]
google_sql_database_instance.named_test_resource: Still destroying... [id=turbottest68934, 10s elapsed]
google_sql_database_instance.named_test_resource: Still destroying... [id=turbottest68934, 20s elapsed]
google_sql_database_instance.named_test_resource: Still destroying... [id=turbottest68934, 30s elapsed]
google_sql_database_instance.named_test_resource: Still destroying... [id=turbottest68934, 40s elapsed]
google_sql_database_instance.named_test_resource: Still destroying... [id=turbottest68934, 50s elapsed]
google_sql_database_instance.named_test_resource: Still destroying... [id=turbottest68934, 1m0s elapsed]
google_sql_database_instance.named_test_resource: Still destroying... [id=turbottest68934, 1m10s elapsed]
google_sql_database_instance.named_test_resource: Still destroying... [id=turbottest68934, 1m20s elapsed]
google_sql_database_instance.named_test_resource: Destruction complete after 1m30s
google_sql_database_instance.named_test_resource: Creating...
google_sql_database_instance.named_test_resource: Still creating... [10s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [20s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [30s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [40s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [50s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [1m0s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [1m10s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [1m20s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [1m30s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [1m40s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [1m50s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [2m0s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [2m10s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [2m20s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [2m30s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [2m40s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [2m50s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [3m0s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [3m10s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [3m20s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [3m30s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [3m40s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [3m50s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [4m0s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [4m10s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [4m20s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [4m30s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [4m40s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [4m50s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [5m0s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [5m10s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [5m20s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [5m30s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [5m40s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [5m50s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [6m0s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [6m10s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [6m20s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [6m30s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [6m40s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [6m50s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [7m0s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [7m10s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [7m20s elapsed]
google_sql_database_instance.named_test_resource: Creation complete after 7m23s [id=turbottest87532]
null_resource.named_test_resource: Creating...
null_resource.named_test_resource: Provisioning with 'local-exec'...
null_resource.named_test_resource (local-exec): Executing: ["/bin/sh" "-c" "gcloud sql backups create --instance turbottest87532"]
null_resource.named_test_resource: Still creating... [10s elapsed]
null_resource.named_test_resource: Still creating... [20s elapsed]
null_resource.named_test_resource: Still creating... [30s elapsed]
null_resource.named_test_resource: Still creating... [40s elapsed]
null_resource.named_test_resource: Still creating... [50s elapsed]
null_resource.named_test_resource: Still creating... [1m0s elapsed]
null_resource.named_test_resource: Still creating... [1m10s elapsed]
null_resource.named_test_resource: Still creating... [1m20s elapsed]
null_resource.named_test_resource: Still creating... [1m30s elapsed]
null_resource.named_test_resource: Still creating... [1m40s elapsed]
null_resource.named_test_resource: Still creating... [1m50s elapsed]
null_resource.named_test_resource: Still creating... [2m0s elapsed]
null_resource.named_test_resource: Still creating... [2m10s elapsed]
null_resource.named_test_resource: Still creating... [2m20s elapsed]
null_resource.named_test_resource: Still creating... [2m30s elapsed]
null_resource.named_test_resource: Still creating... [2m40s elapsed]
null_resource.named_test_resource: Still creating... [2m50s elapsed]
null_resource.named_test_resource: Still creating... [3m0s elapsed]
null_resource.named_test_resource: Still creating... [3m10s elapsed]
null_resource.named_test_resource: Still creating... [3m20s elapsed]
null_resource.named_test_resource: Still creating... [3m30s elapsed]
null_resource.named_test_resource: Still creating... [3m40s elapsed]
null_resource.named_test_resource: Still creating... [3m50s elapsed]
null_resource.named_test_resource: Still creating... [4m0s elapsed]
null_resource.named_test_resource: Still creating... [4m10s elapsed]
null_resource.named_test_resource: Still creating... [4m20s elapsed]
null_resource.named_test_resource: Still creating... [4m30s elapsed]
null_resource.named_test_resource: Still creating... [4m40s elapsed]
null_resource.named_test_resource: Still creating... [4m50s elapsed]
null_resource.named_test_resource: Still creating... [5m0s elapsed]
null_resource.named_test_resource: Still creating... [5m10s elapsed]
null_resource.named_test_resource: Still creating... [5m20s elapsed]
null_resource.named_test_resource: Still creating... [5m30s elapsed]
null_resource.named_test_resource: Still creating... [5m40s elapsed]
null_resource.named_test_resource: Still creating... [5m50s elapsed]
null_resource.named_test_resource: Still creating... [6m0s elapsed]
null_resource.named_test_resource: Still creating... [6m10s elapsed]
null_resource.named_test_resource: Still creating... [6m20s elapsed]
null_resource.named_test_resource: Still creating... [6m30s elapsed]
null_resource.named_test_resource: Still creating... [6m40s elapsed]
null_resource.named_test_resource: Still creating... [6m50s elapsed]
null_resource.named_test_resource: Still creating... [7m0s elapsed]
null_resource.named_test_resource: Still creating... [7m10s elapsed]
null_resource.named_test_resource: Still creating... [7m20s elapsed]
null_resource.named_test_resource: Still creating... [7m30s elapsed]
null_resource.named_test_resource: Still creating... [7m40s elapsed]
null_resource.named_test_resource: Still creating... [7m50s elapsed]
null_resource.named_test_resource: Still creating... [8m0s elapsed]
null_resource.named_test_resource: Still creating... [8m10s elapsed]
null_resource.named_test_resource: Still creating... [8m20s elapsed]
null_resource.named_test_resource: Still creating... [8m30s elapsed]
null_resource.named_test_resource: Still creating... [8m40s elapsed]
null_resource.named_test_resource: Still creating... [8m50s elapsed]
null_resource.named_test_resource: Still creating... [9m0s elapsed]
null_resource.named_test_resource: Still creating... [9m10s elapsed]
null_resource.named_test_resource: Still creating... [9m20s elapsed]
null_resource.named_test_resource: Still creating... [9m30s elapsed]
null_resource.named_test_resource: Still creating... [9m40s elapsed]
null_resource.named_test_resource: Still creating... [9m50s elapsed]
null_resource.named_test_resource: Still creating... [10m0s elapsed]
null_resource.named_test_resource: Still creating... [10m10s elapsed]
null_resource.named_test_resource: Still creating... [10m20s elapsed]
null_resource.named_test_resource: Still creating... [10m30s elapsed]
null_resource.named_test_resource: Still creating... [10m40s elapsed]
null_resource.named_test_resource: Still creating... [10m50s elapsed]
null_resource.named_test_resource: Still creating... [11m0s elapsed]
null_resource.named_test_resource: Still creating... [11m10s elapsed]
null_resource.named_test_resource: Still creating... [11m20s elapsed]
null_resource.named_test_resource: Still creating... [11m30s elapsed]
null_resource.named_test_resource: Still creating... [11m40s elapsed]
null_resource.named_test_resource: Still creating... [11m50s elapsed]
null_resource.named_test_resource: Still creating... [12m0s elapsed]
null_resource.named_test_resource: Still creating... [12m10s elapsed]
null_resource.named_test_resource: Still creating... [12m20s elapsed]
null_resource.named_test_resource: Still creating... [12m30s elapsed]
null_resource.named_test_resource: Still creating... [12m40s elapsed]
null_resource.named_test_resource: Still creating... [12m50s elapsed]
null_resource.named_test_resource: Still creating... [13m0s elapsed]
null_resource.named_test_resource: Still creating... [13m10s elapsed]
null_resource.named_test_resource: Still creating... [13m20s elapsed]
null_resource.named_test_resource: Still creating... [13m30s elapsed]
null_resource.named_test_resource: Still creating... [13m40s elapsed]
null_resource.named_test_resource: Still creating... [13m50s elapsed]
null_resource.named_test_resource: Still creating... [14m0s elapsed]
null_resource.named_test_resource: Still creating... [14m10s elapsed]
null_resource.named_test_resource: Still creating... [14m20s elapsed]
null_resource.named_test_resource: Still creating... [14m30s elapsed]
null_resource.named_test_resource: Still creating... [14m40s elapsed]
null_resource.named_test_resource: Still creating... [14m50s elapsed]
null_resource.named_test_resource: Still creating... [15m0s elapsed]
null_resource.named_test_resource (local-exec): Backing up Cloud SQL instance...
null_resource.named_test_resource: Still creating... [15m10s elapsed]
null_resource.named_test_resource: Still creating... [15m20s elapsed]
null_resource.named_test_resource: Still creating... [15m30s elapsed]
null_resource.named_test_resource: Still creating... [15m40s elapsed]
null_resource.named_test_resource: Still creating... [15m50s elapsed]
null_resource.named_test_resource: Still creating... [16m0s elapsed]
null_resource.named_test_resource: Still creating... [16m10s elapsed]
null_resource.named_test_resource: Still creating... [16m20s elapsed]
null_resource.named_test_resource: Still creating... [16m30s elapsed]
null_resource.named_test_resource: Still creating... [16m40s elapsed]
null_resource.named_test_resource: Still creating... [16m50s elapsed]
null_resource.named_test_resource: Still creating... [17m0s elapsed]
null_resource.named_test_resource: Still creating... [17m10s elapsed]
null_resource.named_test_resource: Still creating... [17m20s elapsed]
null_resource.named_test_resource: Still creating... [17m30s elapsed]
null_resource.named_test_resource: Still creating... [17m40s elapsed]
null_resource.named_test_resource: Still creating... [17m50s elapsed]
null_resource.named_test_resource: Still creating... [18m0s elapsed]
null_resource.named_test_resource: Still creating... [18m10s elapsed]
null_resource.named_test_resource: Still creating... [18m20s elapsed]
null_resource.named_test_resource: Still creating... [18m30s elapsed]
null_resource.named_test_resource: Still creating... [18m40s elapsed]
null_resource.named_test_resource: Still creating... [18m50s elapsed]
null_resource.named_test_resource: Still creating... [19m0s elapsed]
null_resource.named_test_resource: Still creating... [19m10s elapsed]
null_resource.named_test_resource: Still creating... [19m20s elapsed]
null_resource.named_test_resource: Still creating... [19m30s elapsed]
null_resource.named_test_resource: Still creating... [19m41s elapsed]
null_resource.named_test_resource: Still creating... [19m51s elapsed]
null_resource.named_test_resource: Still creating... [20m1s elapsed]
null_resource.named_test_resource (local-exec): ..done.
null_resource.named_test_resource (local-exec): [https://sqladmin.googleapis.com/sql/v1beta4/projects/parker-aaa/instances/turbottest87532] backed up.
null_resource.named_test_resource: Creation complete after 20m10s [id=3000818056761401564]
null_resource.list_resource: Creating...
null_resource.list_resource: Provisioning with 'local-exec'...
null_resource.list_resource (local-exec): Executing: ["/bin/sh" "-c" "gcloud sql backups list --instance turbottest87532 --format json > /private/var/folders/v1/slpk6xvx5977gdtb0j_397kc0000gn/T/tests/gcp_sql_backup/terraform/test/output.json"]
null_resource.list_resource: Still creating... [10s elapsed]
null_resource.list_resource: Still creating... [20s elapsed]
null_resource.list_resource: Still creating... [30s elapsed]
null_resource.list_resource: Still creating... [40s elapsed]
null_resource.list_resource: Still creating... [50s elapsed]
null_resource.list_resource: Still creating... [1m0s elapsed]
null_resource.list_resource: Still creating... [1m10s elapsed]
null_resource.list_resource: Still creating... [1m20s elapsed]
null_resource.list_resource: Still creating... [1m30s elapsed]
null_resource.list_resource: Still creating... [1m40s elapsed]
null_resource.list_resource: Still creating... [1m50s elapsed]
null_resource.list_resource: Still creating... [2m0s elapsed]
null_resource.list_resource: Still creating... [2m10s elapsed]
null_resource.list_resource: Still creating... [2m20s elapsed]
null_resource.list_resource: Still creating... [2m30s elapsed]
null_resource.list_resource: Still creating... [2m40s elapsed]
null_resource.list_resource: Still creating... [2m50s elapsed]
null_resource.list_resource: Still creating... [3m0s elapsed]
null_resource.list_resource: Still creating... [3m10s elapsed]
null_resource.list_resource: Still creating... [3m20s elapsed]
null_resource.list_resource: Still creating... [3m30s elapsed]
null_resource.list_resource: Still creating... [3m40s elapsed]
null_resource.list_resource: Still creating... [3m50s elapsed]
null_resource.list_resource: Still creating... [4m0s elapsed]
null_resource.list_resource: Still creating... [4m10s elapsed]
null_resource.list_resource: Still creating... [4m20s elapsed]
null_resource.list_resource: Still creating... [4m30s elapsed]
null_resource.list_resource: Still creating... [4m40s elapsed]
null_resource.list_resource: Still creating... [4m50s elapsed]
null_resource.list_resource: Still creating... [5m0s elapsed]
null_resource.list_resource: Creation complete after 5m2s [id=4271937199303789970]
data.local_file.input: Reading...
data.local_file.input: Read complete after 0s [id=7ee8eec4e0e990e887f3556ac5d6651c539c8293]

Warning: Deprecated

  with data.null_data_source.resource,
  on variables.tf line 34, in data "null_data_source" "resource":
  34: data "null_data_source" "resource" {

The null_data_source was historically used to construct intermediate values
to re-use elsewhere in configuration, the same can now be achieved using
locals or the terraform_data resource type in Terraform 1.4 and later.

(and one more similar warning elsewhere)

Apply complete! Resources: 3 added, 0 changed, 1 destroyed.

Outputs:

backup_id = "1704951048937"
project_id = "parker-aaa"
resource_name = "turbottest87532"
self_link = "https://sqladmin.googleapis.com/sql/v1beta4/projects/parker-aaa/instances/turbottest87532/backupRuns/1704951048937"

Running SQL query: test-get-query.sql
[
  {
    "instance_name": "turbottest87532",
    "kind": "sql#backupRun",
    "self_link": "https://sqladmin.googleapis.com/sql/v1beta4/projects/parker-aaa/instances/turbottest87532/backupRuns/1704951048937",
    "type": "ON_DEMAND"
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
Warning: terminal options has been deprecated and will be removed in a future version of Steampipe.
These can now be set in a steampipe workspace.
(/Users/parthas/.steampipe/config/default.spc:34,20-42,2)
[
  {
    "instance_name": "turbottest87532",
    "kind": "sql#backupRun",
    "self_link": "https://sqladmin.googleapis.com/sql/v1beta4/projects/parker-aaa/instances/turbottest87532/backupRuns/1704951048937",
    "type": "ON_DEMAND"
  }
]
✔ PASSED

Running SQL query: test-not-found-query.sql
Warning: terminal options has been deprecated and will be removed in a future version of Steampipe.
These can now be set in a steampipe workspace.
(/Users/parthas/.steampipe/config/default.spc:34,20-42,2)
[]
✔ PASSED

TEARDOWN: tests/gcp_sql_backup

SUMMARY:

1/1 passed.
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
> select id, instance_name, status, end_time, start_time, window_start_time, enqueued_time from gcp_sql_backup;
+---------------+---------------+---------+----------+---------------------------+---------------------------+---------------------------+
| id            | instance_name | status  | end_time | start_time                | window_start_time         | enqueued_time             |
+---------------+---------------+---------+----------+---------------------------+---------------------------+---------------------------+
| 1705036282811 | test53        | RUNNING | <null>   | 2024-01-12T10:41:22+05:30 | 2024-01-12T10:41:22+05:30 | 2024-01-12T10:41:22+05:30 |
+---------------+---------------+---------+----------+---------------------------+---------------------------+---------------------------+

Time: 1.6s. Rows fetched: 1. Hydrate calls: 0.
> select id, instance_name, status, end_time, start_time, window_start_time, enqueued_time from gcp_sql_backup;
+---------------+---------------+------------+---------------------------+---------------------------+---------------------------+---------------------------+
| id            | instance_name | status     | end_time                  | start_time                | window_start_time         | enqueued_time             |
+---------------+---------------+------------+---------------------------+---------------------------+---------------------------+---------------------------+
| 1705036282811 | test53        | SUCCESSFUL | 2024-01-12T10:42:44+05:30 | 2024-01-12T10:41:22+05:30 | 2024-01-12T10:41:22+05:30 | 2024-01-12T10:41:22+05:30 |
+---------------+---------------+------------+---------------------------+---------------------------+---------------------------+---------------------------+

Time: 1.7s. Rows fetched: 1. Hydrate calls: 0.

> select id, instance_name, status, end_time, start_time, window_start_time, enqueued_time from gcp_sql_backup;
+---------------+---------------+------------------+----------+------------+---------------------------+---------------------------+
| id            | instance_name | status           | end_time | start_time | window_start_time         | enqueued_time             |
+---------------+---------------+------------------+----------+------------+---------------------------+---------------------------+
| 1705036282811 | test53        | DELETION_PENDING | <null>   | <null>     | 2024-01-12T10:41:22+05:30 | 2024-01-12T10:41:22+05:30 |
+---------------+---------------+------------------+----------+------------+---------------------------+---------------------------+

```
</details>
