### PR TITLE
Fixed Error in gcp_sql_database if instance is not running Closes #584

### DIFF
--- a/gcp/table_gcp_sql_database.go
+++ b/gcp/table_gcp_sql_database.go
@@ -120,8 +120,13 @@ func listSQLDatabases(ctx context.Context, d *plugin.QueryData, h *plugin.Hydrat
 	instance := h.Item.(*sqladmin.DatabaseInstance)
 
 	// ERROR: rpc error: code = Unknown desc = googleapi: Error 400: Invalid request: Invalid request since instance is not running., invalid
-	// Return nil, if the instance not in running state
-	if instance.State != "RUNNABLE" {
+	// Return nil, if the instance not in running state or in stop state
+	// ActivationPolicy specifies when the instance is activated.
+	// - ALWAYS	The instance is always up and running.
+	// - NEVER	The instance never starts.
+	// - ON_DEMAND The instance starts upon receiving requests.(Deprecated)
+	// https://cloud.google.com/sql/docs/mysql/admin-api/rest/v1/instances#SqlActivationPolicy
+	if instance.State != "RUNNABLE" || instance.Settings.ActivationPolicy !=  "ALWAYS" {
 		return nil, nil
 	}
 

--- a/gcp/table_gcp_sql_database.go
+++ b/gcp/table_gcp_sql_database.go
@@ -120,12 +120,14 @@ func listSQLDatabases(ctx context.Context, d *plugin.QueryData, h *plugin.Hydrat
 	instance := h.Item.(*sqladmin.DatabaseInstance)
 
 	// ERROR: rpc error: code = Unknown desc = googleapi: Error 400: Invalid request: Invalid request since instance is not running., invalid
-	// Return nil, if the instance not in running state or in stop state
+	// Return nil, if the instance is not in Runnable state.
 	// ActivationPolicy specifies when the instance is activated.
+        // - SQL_ACTIVATION_POLICY_UNSPECIFIED  Unknown activation plan.
 	// - ALWAYS	The instance is always up and running.
 	// - NEVER	The instance never starts.
-	// - ON_DEMAND The instance starts upon receiving requests.(Deprecated)
+	// - ON_DEMAND  The instance starts upon receiving requests.(Deprecated)
 	// https://cloud.google.com/sql/docs/mysql/admin-api/rest/v1/instances#SqlActivationPolicy
+	
 	if instance.State != "RUNNABLE" || instance.Settings.ActivationPolicy !=  "ALWAYS" {
 		return nil, nil
 	}


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging
customEnv TURBOT_TEST_EXPECTED_TIMEOUT undefined

SETUP: tests/gcp_sql_database []

PRETEST: tests/gcp_sql_database

TEST: tests/gcp_sql_database
Running terraform
data.google_client_config.current: Reading...
data.google_client_config.current: Read complete after 0s [id=projects/"wwokd-kdd"/regions/"us-east1"/zones/"us-east1-b"]
data.null_data_source.resource: Reading...
data.null_data_source.resource: Read complete after 0s [id=static]

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # google_sql_database.named_test_resource will be created
  + resource "google_sql_database" "named_test_resource" {
      + charset         = (known after apply)
      + collation       = (known after apply)
      + deletion_policy = "DELETE"
      + id              = (known after apply)
      + instance        = "turbottest23966"
      + name            = "turbottest23966"
      + project         = "wwokd-kdd"
      + self_link       = (known after apply)
    }

  # google_sql_database_instance.named_test_resource will be created
  + resource "google_sql_database_instance" "named_test_resource" {
      + available_maintenance_versions = (known after apply)
      + connection_name                = (known after apply)
      + database_version               = "MYSQL_5_6"
      + deletion_protection            = false
      + dns_name                       = (known after apply)
      + encryption_key_name            = (known after apply)
      + first_ip_address               = (known after apply)
      + id                             = (known after apply)
      + instance_type                  = (known after apply)
      + ip_address                     = (known after apply)
      + maintenance_version            = (known after apply)
      + master_instance_name           = (known after apply)
      + name                           = "turbottest23966"
      + private_ip_address             = (known after apply)
      + project                        = "wwokd-kdd"
      + psc_service_attachment_link    = (known after apply)
      + public_ip_address              = (known after apply)
      + region                         = "us-east1"
      + self_link                      = (known after apply)
      + server_ca_cert                 = (sensitive value)
      + service_account_email_address  = (known after apply)

      + settings {
          + activation_policy     = "ALWAYS"
          + availability_type     = "ZONAL"
          + connector_enforcement = (known after apply)
          + disk_autoresize       = true
          + disk_autoresize_limit = 0
          + disk_size             = 10
          + disk_type             = "PD_HDD"
          + edition               = "ENTERPRISE"
          + pricing_plan          = "PER_USE"
          + tier                  = "db-f1-micro"
          + user_labels           = (known after apply)
          + version               = (known after apply)
        }
    }

Plan: 2 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + project_id    = "wwokd-kdd"
  + resource_aka  = (known after apply)
  + resource_id   = (known after apply)
  + resource_name = "turbottest23966"
  + self_link     = (known after apply)
google_sql_database_instance.named_test_resource: Creating...
google_sql_database_instance.named_test_resource: Still creating... [10s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [20s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [30s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [40s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [50s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [1m0s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [1m10s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [1m20s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [1m30s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [1m40s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [1m50s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [2m0s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [2m10s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [2m20s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [2m30s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [2m40s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [2m50s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [3m0s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [3m10s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [3m20s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [3m30s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [3m40s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [3m50s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [4m0s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [4m10s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [4m20s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [4m30s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [4m40s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [4m50s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [5m0s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [5m10s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [5m20s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [5m30s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [5m40s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [5m50s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [6m0s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [6m10s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [6m20s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [6m30s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [6m40s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [6m50s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [7m0s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [7m10s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [7m20s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [7m30s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [7m40s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [7m50s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [8m0s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [8m10s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [8m20s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [8m30s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [8m40s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [8m50s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [9m0s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [9m10s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [9m20s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [9m30s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [9m40s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [9m50s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [10m0s elapsed]
google_sql_database_instance.named_test_resource: Still creating... [10m10s elapsed]
google_sql_database_instance.named_test_resource: Creation complete after 10m16s [id=turbottest23966]
google_sql_database.named_test_resource: Creating...
google_sql_database.named_test_resource: Creation complete after 1s [id=projects/wwokd-kdd/instances/turbottest23966/databases/turbottest23966]

Warning: Deprecated

  with data.null_data_source.resource,
  on variables.tf line 33, in data "null_data_source" "resource":
  33: data "null_data_source" "resource" {

The null_data_source was historically used to construct intermediate values
to re-use elsewhere in configuration, the same can now be achieved using
locals or the terraform_data resource type in Terraform 1.4 and later.

(and one more similar warning elsewhere)

Apply complete! Resources: 2 added, 0 changed, 0 destroyed.

Outputs:

project_id = "wwokd-kdd"
resource_aka = "gcp://cloudsql.googleapis.com/projects/wwokd-kdd/instances/turbottest23966/databases/turbottest23966"
resource_id = "projects/wwokd-kdd/instances/turbottest23966/databases/turbottest23966"
resource_name = "turbottest23966"
self_link = "https://sqladmin.googleapis.com/sql/v1beta4/projects/wwokd-kdd/instances/turbottest23966/databases/turbottest23966"

Running SQL query: test-get-query.sql

Time: 3.2s. Rows returned: 1. Rows fetched: 1. Hydrate calls: 0.

Scans:
  1) gcp_sql_database.gcp: Time: 2.9s. Fetched: 1. Hydrates: 0. Quals: name=turbottest23966, instance_name=turbottest23966.

[
  {
    "charset": "utf8",
    "instance_name": "turbottest23966",
    "kind": "sql#database",
    "location": "us-east1",
    "name": "turbottest23966",
    "project": "wwokd-kdd",
    "self_link": "https://sqladmin.googleapis.com/sql/v1beta4/projects/wwokd-kdd/instances/turbottest23966/databases/turbottest23966"
  }
]
✔ PASSED

Running SQL query: test-hydrate-query.sql

Time: 3.3s. Rows returned: 1. Rows fetched: 1. Hydrate calls: 0.

Scans:
  1) gcp_sql_database.gcp: Time: 2.9s. Fetched: 1. Hydrates: 0. Quals: instance_name=turbottest23966, name=turbottest23966.

[
  {
    "instance_name": "turbottest23966",
    "kind": "sql#database",
    "name": "turbottest23966"
  }
]
✔ PASSED

Running SQL query: test-list-query.sql

Time: 3.4s. Rows returned: 1. Rows fetched: 4. Hydrate calls: 0.

Scans:
  1) gcp_sql_database.gcp: Time: 3.2s. Fetched: 4. Hydrates: 0. Quals: name=turbottest23966.

[
  {
    "instance_name": "turbottest23966",
    "name": "turbottest23966"
  }
]
✔ PASSED

Running SQL query: test-not-found-query.sql

Time: 2.2s. Rows returned: 0.
[]
✔ PASSED

Running SQL query: test-turbot-query.sql

Time: 3.2s. Rows returned: 1. Rows fetched: 4. Hydrate calls: 0.

Scans:
  1) gcp_sql_database.gcp: Time: 2.9s. Fetched: 4. Hydrates: 0. Quals: name=turbottest23966.

[
  {
    "akas": [
      "gcp://cloudsql.googleapis.com/projects/wwokd-kdd/instances/turbottest23966/databases/turbottest23966"
    ],
    "title": "turbottest23966"
  }
]
✔ PASSED

POSTTEST: tests/gcp_sql_database

TEARDOWN: tests/gcp_sql_database

SUMMARY:

1/1 passed.
```
</details>

# Example query results
<details>
  <summary>Results</summary>


**Before Fix:**

```
> select name, state, activation_policy from gcp_sql_database_instance
+---------+----------+-------------------+
| name    | state    | activation_policy |
+---------+----------+-------------------+
| test432 | RUNNABLE | ALWAYS            |
+---------+----------+-------------------+

> select * from gcp_sql_database
+--------------------+---------------+--------------+---------+--------------------+----------------------------------------------------------------------------------------------------------------+-------------------------------------->
| name               | instance_name | kind         | charset | collation          | self_link                                                                                                      | sql_server_database_compatibility_lev>
+--------------------+---------------+--------------+---------+--------------------+----------------------------------------------------------------------------------------------------------------+-------------------------------------->
| sys                | test432       | sql#database | utf8mb4 | utf8mb4_0900_ai_ci | https://sqladmin.googleapis.com/sql/v1beta4/projects/wwokd-kdd/instances/test432/databases/sys                | <null>                               >
| information_schema | test432       | sql#database | utf8mb3 | utf8mb3_general_ci | https://sqladmin.googleapis.com/sql/v1beta4/projects/wwokd-kdd/instances/test432/databases/information_schema | <null>                               >
| performance_schema | test432       | sql#database | utf8mb4 | utf8mb4_0900_ai_ci | https://sqladmin.googleapis.com/sql/v1beta4/projects/wwokd-kdd/instances/test432/databases/performance_schema | <null>                               >
| mysql              | test432       | sql#database | utf8mb3 | utf8mb3_general_ci | https://sqladmin.googleapis.com/sql/v1beta4/projects/wwokd-kdd/instances/test432/databases/mysql              | <null>                               >
+--------------------+---------------+--------------+---------+--------------------+----------------------------------------------------------------------------------------------------------------+-------------------------------------->


> select name, state, activation_policy from gcp_sql_database_instance
+---------+----------+-------------------+
| name    | state    | activation_policy |
+---------+----------+-------------------+
| test432 | RUNNABLE | NEVER             |
+---------+----------+-------------------+


> select * from gcp_sql_database

Error: gcp: googleapi: Error 400: Invalid request: Invalid request since instance is not running., invalid (SQLSTATE HV000)

+------+---------------+------+---------+-----------+-----------+-----------------------------------------+------------------------------------+-------+------+----------+---------+--------------------+--------+------+
| name | instance_name | kind | charset | collation | self_link | sql_server_database_compatibility_level | sql_server_database_recovery_model | title | akas | location | project | sp_connection_name | sp_ctx | _ctx |
+------+---------------+------+---------+-----------+-----------+-----------------------------------------+------------------------------------+-------+------+----------+---------+--------------------+--------+------+
+------+---------------+------+---------+-----------+-----------+-----------------------------------------+------------------------------------+-------+------+----------+---------+--------------------+--------+------+
```

**After Fix:**

```
> select name, state, activation_policy from gcp_sql_database_instance
+---------+----------+-------------------+
| name    | state    | activation_policy |
+---------+----------+-------------------+
| test432 | RUNNABLE | NEVER             |
+---------+----------+-------------------+

> select * from gcp_sql_database
+------+---------------+------+---------+-----------+-----------+-----------------------------------------+------------------------------------+-------+------+----------+---------+--------------------+--------+------+
| name | instance_name | kind | charset | collation | self_link | sql_server_database_compatibility_level | sql_server_database_recovery_model | title | akas | location | project | sp_connection_name | sp_ctx | _ctx |
+------+---------------+------+---------+-----------+-----------+-----------------------------------------+------------------------------------+-------+------+----------+---------+--------------------+--------+------+
+------+---------------+------+---------+-----------+-----------+-----------------------------------------+------------------------------------+-------+------+----------+---------+--------------------+--------+------+
```
</details>
