### PR TITLE
Fixed Error in gcp_kubernetes_node_pool table if gke autopilot is used Closes #585

### DIFF
--- a/gcp/table_gcp_kubernetes_node_pool.go
+++ b/gcp/table_gcp_kubernetes_node_pool.go
@@ -212,6 +212,11 @@ func getKubernetesNodePool(ctx context.Context, d *plugin.QueryData, h *plugin.H
 
 	resp, err := service.Projects.Locations.Clusters.NodePools.Get(parent).Do()
 	if err != nil {
+		// This operation is not allowed if the cluster has Autopilot Enabled.
+		// We are getting the error Error: gcp: googleapi: Error 400: Autopilot node pools cannot be accessed or modified.
+		if strings.Contains(err.Error(), "Autopilot node pools cannot be accessed or modified") {
+			return nil, nil
+		}
 		return nil, err
 	}
 

--- a/gcp/table_gcp_kubernetes_node_pool.go
+++ b/gcp/table_gcp_kubernetes_node_pool.go
@@ -148,6 +148,13 @@ func listKubernetesNodePools(ctx context.Context, d *plugin.QueryData, h *plugin
 	// Get the details of Cluster
 	cluster := h.Item.(*container.Cluster)
 
+	// This operation is not allowed if the cluster has Autopilot Enabled.
+	// We are getting the error Error: gcp: googleapi: Error 400: Autopilot node pools cannot be accessed or modified.
+
+	if cluster.Autopilot.Enabled {
+		return nil, nil
+	}
+
 	// Create Service Connection
 	service, err := ContainerService(ctx, d)
 	if err != nil {


### PR DESCRIPTION

# Integration test logs
<details>
  <summary>Logs</summary>
  
```
Add passing integration test logs here
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
Before fix:

select * from gcp_kubernetes_node_pool

Error: gcp: googleapi: Error 400: Autopilot node pools cannot be accessed or modified.
Details:
[
  {
    "@type": "type.googleapis.com/google.rpc.RequestInfo",
    "requestId": "0xd9eb2e4dcdef82ca"
  }
]
, badRequest (SQLSTATE HV000)

+------+-----------+---------------+--------+--------------+--------------------+---------+--------------------+-------------+------------+--------+---------------------+-----------+------------+---------------------+------------------+-------+------+----------+------->
| name | self_link | location_type | status | cluster_name | initial_node_count | version | pod_ipv4_cidr_size | autoscaling | conditions | config | instance_group_urls | locations | management | max_pods_constraint | upgrade_settings | title | akas | location | projec>
+------+-----------+---------------+--------+--------------+--------------------+---------+--------------------+-------------+------------+--------+---------------------+-----------+------------+---------------------+------------------+-------+------+----------+------->
+------+-----------+---------------+--------+--------------+--------------------+---------+--------------------+-------------+------------+--------+---------------------+-----------+------------+---------------------+------------------+-------+------+----------+------->

Time: 3.1s. Rows returned: 0.

After fix:

> select * from gcp_kubernetes_node_pool
+------+-----------+---------------+--------+--------------+--------------------+---------+--------------------+-------------+------------+--------+---------------------+-----------+------------+---------------------+------------------+-------+------+----------+------->
| name | self_link | location_type | status | cluster_name | initial_node_count | version | pod_ipv4_cidr_size | autoscaling | conditions | config | instance_group_urls | locations | management | max_pods_constraint | upgrade_settings | title | akas | location | projec>
+------+-----------+---------------+--------+--------------+--------------------+---------+--------------------+-------------+------------+--------+---------------------+-----------+------------+---------------------+------------------+-------+------+----------+------->
+------+-----------+---------------+--------+--------------+--------------------+---------+--------------------+-------------+------------+--------+---------------------+-----------+------------+---------------------+------------------+-------+------+----------+-------
```
</details>
