### PR TITLE
Fixed the column value for project is always null for the table gcp_alloydb_cluster #616

### DIFF
--- a/gcp/table_gcp_alloydb_cluster.go
+++ b/gcp/table_gcp_alloydb_cluster.go
@@ -203,7 +203,7 @@ func tableGcpAlloyDBCluster(ctx context.Context) *plugin.Table {
 				Description: ColumnDescriptionProject,
 				Type:        proto.ColumnType_STRING,
 				Hydrate:     gcpAlloyDBClusterTurbotData,
-				Transform:   transform.FromField("ProjectId"),
+				Transform:   transform.FromField("Project"),
 			},
 		},
 	}

--- a/gcp/table_gcp_alloydb_instance.go
+++ b/gcp/table_gcp_alloydb_instance.go
@@ -195,7 +195,7 @@ func tableGcpAlloyDBInstance(ctx context.Context) *plugin.Table {
 				Description: ColumnDescriptionProject,
 				Type:        proto.ColumnType_STRING,
 				Hydrate:     gcpAlloyDBInstanceTurbotData,
-				Transform:   transform.FromField("ProjectId"),
+				Transform:   transform.FromField("Project"),
 			},
 		},
 	}


### PR DESCRIPTION

# Integration test logs
<details>
  <summary>Logs</summary>
  
```
Add passing integration test logs here
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
> select
    concat(name, ' [', location, '/', project, ']') as title,
    name,
    _ctx ->> 'connection_name' as cred,
    location,
    project
  from
    gcp_alloydb_cluster
  where
    date_part('day', now()-create_time) < 1

+-------------------------------------------------------------------------------+---------------------------------------------------------+------+----------+------------+
| title                                                                         | name                                                    | cred | location | project    |
+-------------------------------------------------------------------------------+---------------------------------------------------------+------+----------+------------+
| projects/parker-aaa/locations/us-east4/clusters/test-pc [us-east4/parker-aaa] | projects/parker-aaa/locations/us-east4/clusters/test-pc | gcp  | us-east4 | parker-aaa |
+-------------------------------------------------------------------------------+---------------------------------------------------------+------+----------+------------+
```
</details>
