### PR TITLE
Added support for authentication module using pre-generated temporary Impersonate Access Token

### DIFF
--- a/config/gcp.spc
+++ b/config/gcp.spc
@@ -18,7 +18,7 @@ connection "gcp" {
 
   # `impersonate_access_token` (optional) - You can generate an OAuth 2.0 access token by using the gcloud CLI, the REST API, or the Cloud Client Libraries and Google API Client Libraries.
   # Refer https://cloud.google.com/iam/docs/create-short-lived-credentials-direct#gcloud_2 for generating the access token.
-  # impersonate_access_token = "ya29.c.c0ASRK0GZ7mv8lIV0iiudmiGBs9m1gqGfBYZzVRhHY9xQsu82jdCmZZcGe70CjkxcvsCsVXsPeCeGWE6aDl5K561WRcJi1T9l7pTB7fTuWgWDfAzTHye9Kg3z9dc66hVEct_i8seajX9f3WtdQBSqzYvZSenm_jdsuqfyWCSiiz_aVbx5y_MVgx3D_kT2Rz7ePbwSfuqnbsKfiByG0QI8YJlqB1_A6s5pyhITpvWmkNg1baWzqFW5IP9lzvLdGCaTAQ2Nf18IidExI50GLb5NdLQ1Njig_UnVNrEdc-Vke3X3J4PX0fsKY7y4tBcoGlq9Cc9bGEzPHrElEENaJ_iP7WCbZf-b8aUqoqkVQl8Wl15AoJwbrcksjyuXVTg28QpC3cUb6a_aXUnrQcu9Ru1ULRHjVA9JKU0ayu1tpYNLSRxCeM5cMCtGet3f34xCaV7kT1wut6vD4hlpKRfOBHrnd6bTw2dF8Q89m9AA2jHR-X2v68KngKFkvmkTuUEhPJPOXl1VXUAkN1W1oI0ccW8Y04TN_YSreMh56dmeziAZ9O4S_WB9eYcBbgNvW6ghkrQ83UWJ15DeD8hiWPTKFppITzjgaFCQDE4Q1aF5yKlVGFFdpS1Fe9UZvIY4bDKgE645DsSewy-Swiw4wRIiF6wgdwp0cdavl5BoodtI4OSomxxbh3n_u-wJmO12xBXUMiaRMlu72a_ilXow5ynU9U-wdlqScr2uf4bZwZyfUrUX1xXpUJmd8kXka8Skpv6wtOnywQmkWeupbMQXRO504S76u-cXekOdcUSR4RJlZ9s9geB5aWFJ5SmFkwcYXS3Ijh66m_Mq-s2JmI51wd4F-ZY0U75pRw-OmiRX2xtBk5c2mS7gZfoae88MmmU4J2aBwsOwcedX9fUrBl-4QSBxhSRcdsRyFp1eXf0-whBd8mQ9WyJOOb1v9zd1qrmBZpXma2i5ltst6FsizQrxmSb98xROqjY6iqtmqIyshWjydY3RzFYcdOlhb5aMYJd"
+  # impersonate_access_token = "ya29.c.c0ASRK0GZ7mv8lIV0iiudmiGBs...hb5aMYJd"
 
   # `impersonate_service_account` (optional) - The GCP service account (string) which should be impersonated.
   # If not set, no impersonation is done.

--- a/config/gcp.spc
+++ b/config/gcp.spc
@@ -16,6 +16,10 @@ connection "gcp" {
   #   - The standard location (`~/.config/gcloud/application_default_credentials.json`)
   #credentials = "~/.config/gcloud/application_default_credentials.json"
 
+  # `impersonate_access_token` (optional) - You can generate an OAuth 2.0 access token by using the gcloud CLI, the REST API, or the Cloud Client Libraries and Google API Client Libraries.
+  # Refer https://cloud.google.com/iam/docs/create-short-lived-credentials-direct#gcloud_2 for generating the access token.
+  # impersonate_access_token = "ya29.c.c0ASRK0GZ7mv8lIV0iiudmiGBs9m1gqGfBYZzVRhHY9xQsu82jdCmZZcGe70CjkxcvsCsVXsPeCeGWE6aDl5K561WRcJi1T9l7pTB7fTuWgWDfAzTHye9Kg3z9dc66hVEct_i8seajX9f3WtdQBSqzYvZSenm_jdsuqfyWCSiiz_aVbx5y_MVgx3D_kT2Rz7ePbwSfuqnbsKfiByG0QI8YJlqB1_A6s5pyhITpvWmkNg1baWzqFW5IP9lzvLdGCaTAQ2Nf18IidExI50GLb5NdLQ1Njig_UnVNrEdc-Vke3X3J4PX0fsKY7y4tBcoGlq9Cc9bGEzPHrElEENaJ_iP7WCbZf-b8aUqoqkVQl8Wl15AoJwbrcksjyuXVTg28QpC3cUb6a_aXUnrQcu9Ru1ULRHjVA9JKU0ayu1tpYNLSRxCeM5cMCtGet3f34xCaV7kT1wut6vD4hlpKRfOBHrnd6bTw2dF8Q89m9AA2jHR-X2v68KngKFkvmkTuUEhPJPOXl1VXUAkN1W1oI0ccW8Y04TN_YSreMh56dmeziAZ9O4S_WB9eYcBbgNvW6ghkrQ83UWJ15DeD8hiWPTKFppITzjgaFCQDE4Q1aF5yKlVGFFdpS1Fe9UZvIY4bDKgE645DsSewy-Swiw4wRIiF6wgdwp0cdavl5BoodtI4OSomxxbh3n_u-wJmO12xBXUMiaRMlu72a_ilXow5ynU9U-wdlqScr2uf4bZwZyfUrUX1xXpUJmd8kXka8Skpv6wtOnywQmkWeupbMQXRO504S76u-cXekOdcUSR4RJlZ9s9geB5aWFJ5SmFkwcYXS3Ijh66m_Mq-s2JmI51wd4F-ZY0U75pRw-OmiRX2xtBk5c2mS7gZfoae88MmmU4J2aBwsOwcedX9fUrBl-4QSBxhSRcdsRyFp1eXf0-whBd8mQ9WyJOOb1v9zd1qrmBZpXma2i5ltst6FsizQrxmSb98xROqjY6iqtmqIyshWjydY3RzFYcdOlhb5aMYJd"
+
   # `impersonate_service_account` (optional) - The GCP service account (string) which should be impersonated.
   # If not set, no impersonation is done.
   #impersonate_service_account = "YOUR_SERVICE_ACCOUNT"

--- a/docs/index.md
+++ b/docs/index.md
@@ -54,12 +54,12 @@ steampipe plugin install gcp
 
 ### Credentials
 
-| Item | Description |
-| - | - |
-| Credentials | When running locally, you must configure your [Application Default Credentials](https://cloud.google.com/sdk/gcloud/reference/auth/application-default). If you are running in Cloud Shell or Cloud Code, [the tool uses the credentials you provided when you logged in, and manages any authorizations required](https://cloud.google.com/docs/authentication/provide-credentials-adc#cloud-based-dev). |
-| Permissions | Assign the `Viewer` role to your user or service account. You may also need additional permissions related to IAM policies, like `pubsub.subscriptions.getIamPolicy`, `pubsub.topics.getIamPolicy`, `storage.buckets.getIamPolicy`, since these are not included in the `Viewer` role. You can grant these by creating a custom role in your project. |
-| Radius | Each connection represents a single GCP project. |
-| Resolution |  1. Credentials from the JSON file specified by the `credentials` parameter in your steampipe config.<br />2. Credentials from the JSON file specified by the `GOOGLE_APPLICATION_CREDENTIALS` environment variable.<br />3. Credentials from the default JSON file location (~/.config/gcloud/application_default_credentials.json). <br />4. Credentials from [the metadata server](https://cloud.google.com/docs/authentication/application-default-credentials#attached-sa)|
+| Item        | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Credentials | When running locally, you must configure your [Application Default Credentials](https://cloud.google.com/sdk/gcloud/reference/auth/application-default). If you are running in Cloud Shell or Cloud Code, [the tool uses the credentials you provided when you logged in, and manages any authorizations required](https://cloud.google.com/docs/authentication/provide-credentials-adc#cloud-based-dev).                                                                      |
+| Permissions | Assign the `Viewer` role to your user or service account. You may also need additional permissions related to IAM policies, like `pubsub.subscriptions.getIamPolicy`, `pubsub.topics.getIamPolicy`, `storage.buckets.getIamPolicy`, since these are not included in the `Viewer` role. You can grant these by creating a custom role in your project.                                                                                                                          |
+| Radius      | Each connection represents a single GCP project.                                                                                                                                                                                                                                                                                                                                                                                                                               |
+| Resolution  | 1. Credentials from the JSON file specified by the `credentials` parameter in your steampipe config.<br />2. Credentials from the JSON file specified by the `GOOGLE_APPLICATION_CREDENTIALS` environment variable.<br />3. Credentials from the default JSON file location (~/.config/gcloud/application_default_credentials.json). <br />4. Credentials from [the metadata server](https://cloud.google.com/docs/authentication/application-default-credentials#attached-sa) |
 
 ### Configuration
 
@@ -83,6 +83,10 @@ connection "gcp" {
   #   - The path specified in the `GOOGLE_APPLICATION_CREDENTIALS` environment variable, if set; otherwise
   #   - The standard location (`~/.config/gcloud/application_default_credentials.json`)
   #credentials = "~/.config/gcloud/application_default_credentials.json"
+
+  # `impersonate_access_token` (optional) - You can generate an OAuth 2.0 access token by using the gcloud CLI, the REST API, or the Cloud Client Libraries and Google API Client Libraries.
+  # Refer https://cloud.google.com/iam/docs/create-short-lived-credentials-direct#gcloud_2 for generating the access token.
+  # impersonate_access_token = "ya29.c.c0ASRK0GZ7mv8lIV0iiudmiGBs9m1gqGfBYZzVRhHY9xQsu82jdCmZZcGe70CjkxcvsCsVXsPeCeGWE6aDl5K561WRcJi1T9l7pTB7fTuWgWDfAzTHye9Kg3z9dc66hVEct_i8seajX9f3WtdQBSqzYvZSenm_jdsuqfyWCSiiz_aVbx5y_MVgx3D_kT2Rz7ePbwSfuqnbsKfiByG0QI8YJlqB1_A6s5pyhITpvWmkNg1baWzqFW5IP9lzvLdGCaTAQ2Nf18IidExI50GLb5NdLQ1Njig_UnVNrEdc-Vke3X3J4PX0fsKY7y4tBcoGlq9Cc9bGEzPHrElEENaJ_iP7WCbZf-b8aUqoqkVQl8Wl15AoJwbrcksjyuXVTg28QpC3cUb6a_aXUnrQcu9Ru1ULRHjVA9JKU0ayu1tpYNLSRxCeM5cMCtGet3f34xCaV7kT1wut6vD4hlpKRfOBHrnd6bTw2dF8Q89m9AA2jHR-X2v68KngKFkvmkTuUEhPJPOXl1VXUAkN1W1oI0ccW8Y04TN_YSreMh56dmeziAZ9O4S_WB9eYcBbgNvW6ghkrQ83UWJ15DeD8hiWPTKFppITzjgaFCQDE4Q1aF5yKlVGFFdpS1Fe9UZvIY4bDKgE645DsSewy-Swiw4wRIiF6wgdwp0cdavl5BoodtI4OSomxxbh3n_u-wJmO12xBXUMiaRMlu72a_ilXow5ynU9U-wdlqScr2uf4bZwZyfUrUX1xXpUJmd8kXka8Skpv6wtOnywQmkWeupbMQXRO504S76u-cXekOdcUSR4RJlZ9s9geB5aWFJ5SmFkwcYXS3Ijh66m_Mq-s2JmI51wd4F-ZY0U75pRw-OmiRX2xtBk5c2mS7gZfoae88MmmU4J2aBwsOwcedX9fUrBl-4QSBxhSRcdsRyFp1eXf0-whBd8mQ9WyJOOb1v9zd1qrmBZpXma2i5ltst6FsizQrxmSb98xROqjY6iqtmqIyshWjydY3RzFYcdOlhb5aMYJd"
 
   # `impersonate_service_account` (optional) - The GCP service account (string) which should be impersonated.
   # If not set, no impersonation is done.
@@ -119,6 +123,18 @@ connection "gcp_my_other_project" {
   plugin      = "gcp"
   project     = "my-other-project"
   credentials = "/home/me/my-service-account-creds.json"
+}
+```
+
+### Use impersonate access token
+
+Generate Impersonate access token using: [Gcloud CLI command](https://cloud.google.com/iam/docs/create-short-lived-credentials-direct#gcloud_2).
+
+```hcl
+connection "gcp_my_other_project" {
+  plugin                   = "gcp"
+  project                  = "my-other-project"
+  impersonate_access_token = "ya29.c.c0ASRK0GbScRxRY5CoZy3IzRP2xmgXKKBCO2gS50REHF..."
 }
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -112,7 +112,7 @@ connection "gcp" {
 
 By default, the GCP plugin uses your [Application Default Credentials](https://cloud.google.com/sdk/gcloud/reference/auth/application-default) to connect to GCP. If you have not set up ADC, simply run `gcloud auth application-default login`. This command will prompt you to log in, and then will download the application default credentials to ~/.config/gcloud/application_default_credentials.json.
 
-For users with multiple GCP project and more complex authentication use cases, here are some examples of advanced configuration options:
+For users with multiple GCP projects and more complex authentication use cases, here are some examples of advanced configuration options:
 
 ### Use a service account
 
@@ -126,9 +126,9 @@ connection "gcp_my_other_project" {
 }
 ```
 
-### Use impersonate access token
+### Use impersonation access token
 
-Generate Impersonate access token using: [Gcloud CLI command](https://cloud.google.com/iam/docs/create-short-lived-credentials-direct#gcloud_2).
+Generate an impersonate access token using: [gcloud CLI command](https://cloud.google.com/iam/docs/create-short-lived-credentials-direct#gcloud_2).
 
 ```hcl
 connection "gcp_my_other_project" {

--- a/docs/index.md
+++ b/docs/index.md
@@ -86,7 +86,7 @@ connection "gcp" {
 
   # `impersonate_access_token` (optional) - You can generate an OAuth 2.0 access token by using the gcloud CLI, the REST API, or the Cloud Client Libraries and Google API Client Libraries.
   # Refer https://cloud.google.com/iam/docs/create-short-lived-credentials-direct#gcloud_2 for generating the access token.
-  # impersonate_access_token = "ya29.c.c0ASRK0GZ7mv8lIV0iiudmiGBs9m1gqGfBYZzVRhHY9xQsu82jdCmZZcGe70CjkxcvsCsVXsPeCeGWE6aDl5K561WRcJi1T9l7pTB7fTuWgWDfAzTHye9Kg3z9dc66hVEct_i8seajX9f3WtdQBSqzYvZSenm_jdsuqfyWCSiiz_aVbx5y_MVgx3D_kT2Rz7ePbwSfuqnbsKfiByG0QI8YJlqB1_A6s5pyhITpvWmkNg1baWzqFW5IP9lzvLdGCaTAQ2Nf18IidExI50GLb5NdLQ1Njig_UnVNrEdc-Vke3X3J4PX0fsKY7y4tBcoGlq9Cc9bGEzPHrElEENaJ_iP7WCbZf-b8aUqoqkVQl8Wl15AoJwbrcksjyuXVTg28QpC3cUb6a_aXUnrQcu9Ru1ULRHjVA9JKU0ayu1tpYNLSRxCeM5cMCtGet3f34xCaV7kT1wut6vD4hlpKRfOBHrnd6bTw2dF8Q89m9AA2jHR-X2v68KngKFkvmkTuUEhPJPOXl1VXUAkN1W1oI0ccW8Y04TN_YSreMh56dmeziAZ9O4S_WB9eYcBbgNvW6ghkrQ83UWJ15DeD8hiWPTKFppITzjgaFCQDE4Q1aF5yKlVGFFdpS1Fe9UZvIY4bDKgE645DsSewy-Swiw4wRIiF6wgdwp0cdavl5BoodtI4OSomxxbh3n_u-wJmO12xBXUMiaRMlu72a_ilXow5ynU9U-wdlqScr2uf4bZwZyfUrUX1xXpUJmd8kXka8Skpv6wtOnywQmkWeupbMQXRO504S76u-cXekOdcUSR4RJlZ9s9geB5aWFJ5SmFkwcYXS3Ijh66m_Mq-s2JmI51wd4F-ZY0U75pRw-OmiRX2xtBk5c2mS7gZfoae88MmmU4J2aBwsOwcedX9fUrBl-4QSBxhSRcdsRyFp1eXf0-whBd8mQ9WyJOOb1v9zd1qrmBZpXma2i5ltst6FsizQrxmSb98xROqjY6iqtmqIyshWjydY3RzFYcdOlhb5aMYJd"
+  # impersonate_access_token = "ya29.c.c0ASRK0GZ7mv8lIV0iiudmiGBs9m1gqGfBYZzV...aMYJd"
 
   # `impersonate_service_account` (optional) - The GCP service account (string) which should be impersonated.
   # If not set, no impersonation is done.
@@ -134,7 +134,7 @@ Generate Impersonate access token using: [Gcloud CLI command](https://cloud.goog
 connection "gcp_my_other_project" {
   plugin                   = "gcp"
   project                  = "my-other-project"
-  impersonate_access_token = "ya29.c.c0ASRK0GbScRxRY5CoZy3IzRP2xmgXKKBCO2gS50REHF..."
+  impersonate_access_token = "ya29.c.c0ASRK0GZ7mv8lIV0iiudmiGBs9m1gqGfBYZzV...aMYJd"
 }
 ```
 

--- a/gcp/connection_config.go
+++ b/gcp/connection_config.go
@@ -8,6 +8,7 @@ type gcpConfig struct {
 	Project                   *string  `hcl:"project"`
 	Credentials               *string  `hcl:"credentials"`
 	CredentialFile            *string  `hcl:"credential_file"`
+	ImpersonateAccessToken    *string  `hcl:"impersonate_access_token"`
 	ImpersonateServiceAccount *string  `hcl:"impersonate_service_account"`
 	IgnoreErrorCodes          []string `hcl:"ignore_error_codes,optional"`
 	QuotaProject              *string  `hcl:"quota_project,optional"`

--- a/gcp/utils.go
+++ b/gcp/utils.go
@@ -17,6 +17,7 @@ import (
 	"github.com/turbot/steampipe-plugin-sdk/v5/memoize"
 	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
 	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
+	"golang.org/x/oauth2"
 	"google.golang.org/api/impersonate"
 	"google.golang.org/api/option"
 )
@@ -197,6 +198,14 @@ func setSessionConfig(ctx context.Context, connection *plugin.Connection) []opti
 		opts = append(opts, option.WithCredentialsJSON([]byte(contents)))
 	} else if gcpConfig.CredentialFile != nil {
 		opts = append(opts, option.WithCredentialsFile(*gcpConfig.CredentialFile))
+	}
+
+	if gcpConfig.ImpersonateAccessToken != nil {
+		tokenConfig := oauth2.Token{
+			AccessToken: *gcpConfig.ImpersonateAccessToken,
+		}
+		staticTokenSource := oauth2.StaticTokenSource(&tokenConfig)
+		opts = append(opts, option.WithTokenSource(staticTokenSource))
 	}
 
 	if gcpConfig.ImpersonateServiceAccount != nil {


### PR DESCRIPTION

# Integration test logs
<details>
  <summary>Logs</summary>
  
```
Add passing integration test logs here
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
> select * from gcp_project
+------------+------------+--------------------------------------------------------------------+----------------+-----------------+---------------------------+--------------------------------------+------------------------------------->
| name       | project_id | self_link                                                          | project_number | lifecycle_state | create_time               | parent                               | labels                              >
+------------+------------+--------------------------------------------------------------------+----------------+-----------------+---------------------------+--------------------------------------+------------------------------------->
| tmrter-abb | tmrter-abb | https://cloudresourcemanager.googleapis.com/v1/projects/tmrter-abb | 893720417364   | ACTIVE          | 2019-05-22T17:38:03+05:30 | {"id":"13358535532","type":"folder"} | {"budget":"30","firebase":"enabled",>
+------------+------------+--------------------------------------------------------------------+----------------+-----------------+---------------------------+--------------------------------------+------------------------------------->
```
</details>
