### PR TITLE
Fixed the cache key issue in SecretManager service client creation

### DIFF
--- a/gcp/service.go
+++ b/gcp/service.go
@@ -719,7 +719,7 @@ func RedisService(ctx context.Context, d *plugin.QueryData) (*redis.CloudRedisCl
 
 func SecretManagerService(ctx context.Context, d *plugin.QueryData) (*secretmanager.Service, error) {
 	// have we already created and cached the service?
-	serviceCacheKey := "RedisService"
+	serviceCacheKey := "SecretManager"
 	if cachedData, ok := d.ConnectionManager.Cache.Get(serviceCacheKey); ok {
 		return cachedData.(*secretmanager.Service), nil
 	}

--- a/gcp/service.go
+++ b/gcp/service.go
@@ -719,7 +719,7 @@ func RedisService(ctx context.Context, d *plugin.QueryData) (*redis.CloudRedisCl
 
 func SecretManagerService(ctx context.Context, d *plugin.QueryData) (*secretmanager.Service, error) {
 	// have we already created and cached the service?
-	serviceCacheKey := "SecretManager"
+	serviceCacheKey := "SecretManagerService"
 	if cachedData, ok := d.ConnectionManager.Cache.Get(serviceCacheKey); ok {
 		return cachedData.(*secretmanager.Service), nil
 	}


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
Add passing integration test logs here
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
> select * from gcp_redis_instance
+---------+--------------+--------+---------------+-------------------------+---------------+-------------------+--------------------+------------+------+---------------------+---------------------------+-------+----------------+------>
| name    | display_name | labels | location_id   | alternative_location_id | redis_version | reserved_ip_range | secondary_ip_range | host       | port | current_location_id | create_time               | state | status_message | redis>
+---------+--------------+--------+---------------+-------------------------+---------------+-------------------+--------------------+------------+------+---------------------+---------------------------+-------+----------------+------>
| test-pc |              | <null> | us-central1-b |                         | REDIS_7_0     | 10.16.65.0/29     |                    | 10.16.65.3 | 6379 | us-central1-b       | 2024-07-30T17:12:21+05:30 | 2     |                | <null>
+---------+--------------+--------+---------------+-------------------------+---------------+-------------------+--------------------+------------+------+---------------------+---------------------------+-------+----------------+------
```
</details>
