### PR TITLE
Add table gcp_composer_environment Closes #637

### DIFF
--- a/docs/tables/gcp_composer_environment.md
+++ b/docs/tables/gcp_composer_environment.md
@@ -1,0 +1,149 @@
+---
+title: "Steampipe Table: gcp_composer_environment - Query GCP Composer Environments using SQL"
+description: "Allows users to query GCP Composer environments, providing detailed information on environment configurations, resources, and associated services."
+---
+
+# Table: gcp_composer_environment - Query GCP Composer Environments using SQL
+
+Google Cloud Composer is a fully managed workflow orchestration service built on Apache Airflow. The `gcp_composer_environment` table in Steampipe allows you to query information about Cloud Composer environments in your GCP environment, including details about Airflow configurations, node settings, security configurations, and more.
+
+## Table Usage Guide
+
+The `gcp_composer_environment` table is useful for cloud administrators, DevOps engineers, and data engineers who need to gather detailed insights into their Cloud Composer environments. You can query various aspects of the environment, such as its Airflow URI, node configurations, software settings, and network access controls. This table is particularly helpful for monitoring environment states, managing Airflow settings, and ensuring that your workflows are running in a secure and optimized environment.
+
+## Examples
+
+### Basic info
+Retrieve basic information about Composer environments, including their name, location, and state.
+
+```sql+postgres
+select
+  name,
+  location,
+  state,
+  airflow_uri,
+  create_time
+from
+  gcp_composer_environment;
+```
+
+```sql+sqlite
+select
+  name,
+  location,
+  state,
+  airflow_uri,
+  create_time
+from
+  gcp_composer_environment;
+```
+
+### List environments by size
+Identify Composer environments based on their size, such as "ENVIRONMENT_SIZE_SMALL" or "ENVIRONMENT_SIZE_LARGE."
+
+```sql+postgres
+select
+  name,
+  environment_size,
+  location,
+  project
+from
+  gcp_composer_environment
+where
+  environment_size = 'ENVIRONMENT_SIZE_SMALL';
+```
+
+```sql+sqlite
+select
+  name,
+  environment_size,
+  location,
+  project
+from
+  gcp_composer_environment
+where
+  environment_size = 'ENVIRONMENT_SIZE_SMALL';
+```
+
+### List environments with specific node configurations
+Retrieve environments with specific node configurations, such as node count and machine types.
+
+```sql+postgres
+select
+  name,
+  node_count,
+  node_config ->> 'machineType' as machine_type,
+  location,
+  project
+from
+  gcp_composer_environment
+where
+  node_count > 0;
+```
+
+```sql+sqlite
+select
+  name,
+  node_count,
+  json_extract(node_config, '$.machineType') as machine_type,
+  location,
+  project
+from
+  gcp_composer_environment
+where
+  node_count > 0;
+```
+
+### List environments with specific network access controls
+Identify environments that have specific network-level access controls for the Airflow web server.
+
+```sql+postgres
+select
+  name,
+  jsonb_path_query_array(web_server_network_access_control, '$.allowedIpRanges[*].value') as allowed_ip_ranges,
+  location,
+  project
+from
+  gcp_composer_environment
+where
+  web_server_network_access_control is not null;
+```
+
+```sql+sqlite
+select
+  name,
+  json_extract(web_server_network_access_control, '$.allowedIpRanges[0].value') as allowed_ip_ranges,
+  location,
+  project
+from
+  gcp_composer_environment
+where
+  web_server_network_access_control is not null;
+```
+
+### List environments with scheduled snapshot configurations
+Fetch environments that have scheduled snapshot configurations enabled for recovery.
+
+```sql+postgres
+select
+  name,
+  recovery_config ->> 'scheduledSnapshotsConfig' as scheduled_snapshots_config,
+  location,
+  project
+from
+  gcp_composer_environment
+where
+  recovery_config ->> 'scheduledSnapshotsConfig' is not null;
+```
+
+```sql+sqlite
+select
+  name,
+  json_extract(recovery_config, '$.scheduledSnapshotsConfig') as scheduled_snapshots_config,
+  location,
+  project
+from
+  gcp_composer_environment
+where
+  json_extract(recovery_config, '$.scheduledSnapshotsConfig') is not null;
+```

--- a/gcp/plugin.go
+++ b/gcp/plugin.go
@@ -54,6 +54,7 @@ func Plugin(ctx context.Context) *plugin.Plugin {
 			"gcp_cloud_identity_group_membership":                     tableGcpCloudIdentityGroupMembership(ctx),
 			"gcp_cloudfunctions_function":                             tableGcpCloudfunctionFunction(ctx),
 			"gcp_cloud_run_service":                                   tableGcpCloudRunService(ctx),
+			"gcp_composer_environment":                                tableGcpComposerEnvironment(ctx),
 			"gcp_compute_address":                                     tableGcpComputeAddress(ctx),
 			"gcp_compute_autoscaler":                                  tableGcpComputeAutoscaler(ctx),
 			"gcp_compute_backend_bucket":                              tableGcpComputeBackendBucket(ctx),

--- a/gcp/service.go
+++ b/gcp/service.go
@@ -20,6 +20,7 @@ import (
 	"google.golang.org/api/cloudidentity/v1"
 	"google.golang.org/api/cloudkms/v1"
 	"google.golang.org/api/cloudresourcemanager/v1"
+	"google.golang.org/api/composer/v1"
 	"google.golang.org/api/compute/v1"
 	"google.golang.org/api/container/v1"
 	"google.golang.org/api/dataproc/v1"
@@ -415,6 +416,27 @@ func ComputeService(ctx context.Context, d *plugin.QueryData) (*compute.Service,
 
 	// so it was not in cache - create service
 	svc, err := compute.NewService(ctx, opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	d.ConnectionManager.Cache.Set(serviceCacheKey, svc)
+	return svc, nil
+}
+
+// ComposerService returns the service connection for GCP Composer service
+func ComposerService(ctx context.Context, d *plugin.QueryData) (*composer.Service, error) {
+	// have we already created and cached the service?
+	serviceCacheKey := "ComposerService"
+	if cachedData, ok := d.ConnectionManager.Cache.Get(serviceCacheKey); ok {
+		return cachedData.(*composer.Service), nil
+	}
+
+	// To get config arguments from plugin config file
+	opts := setSessionConfig(ctx, d.Connection)
+
+	// so it was not in cache - create service
+	svc, err := composer.NewService(ctx, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/gcp/table_gcp_composer_environment.go
+++ b/gcp/table_gcp_composer_environment.go
@@ -40,7 +40,7 @@ func tableGcpComposerEnvironment(ctx context.Context) *plugin.Table {
 			{
 				Name:        "state",
 				Description: "The current state of the environment.",
-				Type:        proto.ColumnType_IPADDR,
+				Type:        proto.ColumnType_STRING,
 			},
 			{
 				Name:        "create_time",
@@ -235,7 +235,8 @@ func listComposerEnvironments(ctx context.Context, d *plugin.QueryData, h *plugi
 
 	parent := "projects/" + project + "/locations/" + location
 
-	resp := service.Projects.Locations.Environments.List(parent). Context(ctx).PageSize(*pageSize)
+	resp := service.Projects.Locations.Environments.List(parent).PageSize(*pageSize)
+
 	if err := resp.Pages(ctx, func(page *composer.ListEnvironmentsResponse) error {
 		for _, item := range page.Environments {
 			d.StreamListItem(ctx, item)

--- a/gcp/table_gcp_composer_environment.go
+++ b/gcp/table_gcp_composer_environment.go
@@ -95,6 +95,12 @@ func tableGcpComposerEnvironment(ctx context.Context) *plugin.Table {
 				Transform:   transform.FromField("Config.ResilienceMode"),
 			},
 			{
+				Name:        "software_config_bucket",
+				Description: "Storage configuration for this environment.",
+				Type:        proto.ColumnType_STRING,
+				Transform: transform.FromField("StorageConfig.Bucket"),
+			},
+			{
 				Name:        "data_retention_config",
 				Description: "The configuration setting for Airflow database data retention mechanism.",
 				Type:        proto.ColumnType_JSON,

--- a/gcp/table_gcp_composer_environment.go
+++ b/gcp/table_gcp_composer_environment.go
@@ -95,7 +95,7 @@ func tableGcpComposerEnvironment(ctx context.Context) *plugin.Table {
 				Transform:   transform.FromField("Config.ResilienceMode"),
 			},
 			{
-				Name:        "software_config_bucket",
+				Name:        "storage_config_bucket",
 				Description: "Storage configuration for this environment.",
 				Type:        proto.ColumnType_STRING,
 				Transform: transform.FromField("StorageConfig.Bucket"),

--- a/gcp/table_gcp_composer_environment.go
+++ b/gcp/table_gcp_composer_environment.go
@@ -1,0 +1,306 @@
+package gcp
+
+import (
+	"context"
+	"strings"
+
+	"github.com/turbot/go-kit/types"
+	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
+
+	"google.golang.org/api/composer/v1"
+)
+
+//// TABLE DEFINITION
+
+func tableGcpComposerEnvironment(ctx context.Context) *plugin.Table {
+	return &plugin.Table{
+		Name:        "gcp_composer_environment",
+		Description: "GCP Composer Environment",
+		Get: &plugin.GetConfig{
+			KeyColumns: plugin.SingleColumn("name"),
+			Hydrate:    getComposerEnvironment,
+		},
+		List: &plugin.ListConfig{
+			Hydrate: listComposerEnvironments,
+		},
+		GetMatrixItemFunc: BuildComputeLocationList, // The package at https://pkg.go.dev/google.golang.org/api/composer/v1#ProjectsLocationsService does not provide an API to list all supported regions for the Composer service, so we utilized the `BuildComputeLocationList` function instead.
+		Columns: []*plugin.Column{
+			{
+				Name:        "name",
+				Description: "The resource name of the environment.",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "uuid",
+				Description: "The UUID (Universally Unique IDentifier) associated with this environment.",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "state",
+				Description: "The current state of the environment.",
+				Type:        proto.ColumnType_IPADDR,
+			},
+			{
+				Name:        "create_time",
+				Description: "The time at which this environment was created.",
+				Type:        proto.ColumnType_TIMESTAMP,
+			},
+			{
+				Name:        "update_time",
+				Description: "The time at which this environment was last modified.",
+				Type:        proto.ColumnType_TIMESTAMP,
+			},
+			{
+				Name:        "airflow_byoid_uri",
+				Description: "The 'bring your own identity' variant of the URI of the Apache Airflow Web UI hosted within this environment.",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("Config.AirflowByoidUri"),
+			},
+			{
+				Name:        "airflow_uri",
+				Description: "The URI of the Apache Airflow Web UI hosted within this environment.",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("Config.AirflowUri"),
+			},
+			{
+				Name:        "dag_gcs_prefix",
+				Description: "The Cloud Storage prefix of the DAGs for this environment.",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("Config.DagGcsPrefix"),
+			},
+			{
+				Name:        "environment_size",
+				Description: "The size of the Cloud Composer environment.",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("Config.EnvironmentSize"),
+			},
+			{
+				Name:        "gke_cluster",
+				Description: "The Kubernetes Engine cluster used to run this environment.",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("Config.GkeCluster"),
+			},
+			{
+				Name:        "node_count",
+				Description: "The number of nodes in the Kubernetes Engine cluster that will be used to run this environment.",
+				Type:        proto.ColumnType_INT,
+				Transform:   transform.FromField("Config.NodeCount"),
+			},
+			{
+				Name:        "resilience_mode",
+				Description: "Resilience mode of the cloud composer environment.",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("Config.ResilienceMode"),
+			},
+			{
+				Name:        "data_retention_config",
+				Description: "The configuration setting for Airflow database data retention mechanism.",
+				Type:        proto.ColumnType_JSON,
+				Transform:   transform.FromField("Config.DataRetentionConfig"),
+			},
+			{
+				Name:        "database_config",
+				Description: "The configuration settings for Cloud SQL instance used internally by Apache Airflow software.",
+				Type:        proto.ColumnType_JSON,
+				Transform:   transform.FromField("Config.DatabaseConfig"),
+			},
+			{
+				Name:        "encryption_config",
+				Description: "The encryption options for the Cloud Composer environment and its dependencies. Cannot be updated.",
+				Type:        proto.ColumnType_JSON,
+				Transform:   transform.FromField("Config.EncryptionConfig"),
+			},
+			{
+				Name:        "maintenance_window",
+				Description: "The maintenance window is the period when Cloud Composer components may undergo maintenance.",
+				Type:        proto.ColumnType_JSON,
+				Transform:   transform.FromField("Config.MaintenanceWindow"),
+			},
+			{
+				Name:        "master_authorized_networks_config",
+				Description: "The configuration options for GKE cluster master authorized networks.",
+				Type:        proto.ColumnType_JSON,
+				Transform:   transform.FromField("Config.MasterAuthorizedNetworksConfig"),
+			},
+			{
+				Name:        "node_config",
+				Description: "The configuration used for the Kubernetes Engine cluster.",
+				Type:        proto.ColumnType_JSON,
+				Transform:   transform.FromField("Config.NodeConfig"),
+			},
+			{
+				Name:        "private_environment_config",
+				Description: "The configuration used for the Private IP Cloud Composer environment.",
+				Type:        proto.ColumnType_JSON,
+				Transform:   transform.FromField("Config.PrivateEnvironmentConfig"),
+			},
+			{
+				Name:        "recovery_config",
+				Description: "The Recovery settings configuration of an environment.",
+				Type:        proto.ColumnType_JSON,
+				Transform:   transform.FromField("Config.RecoveryConfig"),
+			},
+			{
+				Name:        "software_config",
+				Description: "The configuration settings for software inside the environment.",
+				Type:        proto.ColumnType_JSON,
+				Transform:   transform.FromField("Config.SoftwareConfig"),
+			},
+			{
+				Name:        "web_server_config",
+				Description: "The configuration settings for the Airflow web server App Engine instance.",
+				Type:        proto.ColumnType_JSON,
+				Transform:   transform.FromField("Config.WebServerConfig"),
+			},
+			{
+				Name:        "web_server_network_access_control",
+				Description: "The network-level access control policy for the Airflow web server.",
+				Type:        proto.ColumnType_JSON,
+				Transform:   transform.FromField("Config.WebServerNetworkAccessControl"),
+			},
+			{
+				Name:        "workloads_config",
+				Description: "The workloads configuration settings for the GKE cluster associated with the Cloud Composer environment.",
+				Type:        proto.ColumnType_JSON,
+				Transform:   transform.FromField("Config.WorkloadsConfig"),
+			},
+
+			// standard steampipe columns
+			{
+				Name:        "title",
+				Description: ColumnDescriptionTitle,
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("Name").Transform(lastPathElement),
+			},
+			{
+				Name:        "tags",
+				Description: ColumnDescriptionTags,
+				Type:        proto.ColumnType_JSON,
+				Transform:   transform.FromField("Labels"),
+			},
+			{
+				Name:        "akas",
+				Description: ColumnDescriptionAkas,
+				Type:        proto.ColumnType_JSON,
+				Transform:   transform.FromP(composerEnvironmentTurbotData, "Akas"),
+			},
+
+			// standard gcp columns
+			{
+				Name:        "location",
+				Description: ColumnDescriptionLocation,
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromP(composerEnvironmentTurbotData, "Location"),
+			},
+			{
+				Name:        "project",
+				Description: ColumnDescriptionProject,
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromP(composerEnvironmentTurbotData, "Project"),
+			},
+		},
+	}
+}
+
+//// LIST FUNCTION
+
+func listComposerEnvironments(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+
+	location := d.EqualsQualString(matrixKeyLocation)
+
+	// Create Service Connection
+	service, err := ComposerService(ctx, d)
+	if err != nil {
+		plugin.Logger(ctx).Error("gcp_composer_environment.listComposerEnvironments", "service_error", err)
+		return nil, err
+	}
+
+	pageSize := types.Int64(500)
+	limit := d.QueryContext.Limit
+	if d.QueryContext.Limit != nil {
+		if *limit < *pageSize {
+			pageSize = limit
+		}
+	}
+
+	// Get project details
+
+	projectId, err := getProject(ctx, d, h)
+	if err != nil {
+		return nil, err
+	}
+	project := projectId.(string)
+
+	parent := "projects/" + project + "/locations/" + location
+
+	resp := service.Projects.Locations.Environments.List(parent). Context(ctx).PageSize(*pageSize)
+	if err := resp.Pages(ctx, func(page *composer.ListEnvironmentsResponse) error {
+		for _, item := range page.Environments {
+			d.StreamListItem(ctx, item)
+
+			// Check if context has been cancelled or if the limit has been hit (if specified)
+			// if there is a limit, it will return the number of rows required to reach this limit
+			if d.RowsRemaining(ctx) == 0 {
+				page.NextPageToken = ""
+				return nil
+			}
+		}
+		return nil
+	}); err != nil {
+		plugin.Logger(ctx).Error("gcp_composer_environment.listComposerEnvironments", "api_error", err)
+		return nil, err
+	}
+
+	return nil, nil
+}
+
+//// HYDRATE FUNCTIONS
+
+func getComposerEnvironment(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+	location := d.EqualsQualString(matrixKeyLocation)
+
+	// Create Service Connection
+	service, err := ComposerService(ctx, d)
+	if err != nil {
+		return nil, err
+	}
+
+	name := d.EqualsQuals["name"].GetStringValue()
+
+	// Empty check
+	if name == "" {
+		return nil, nil
+	}
+
+	// Restrict API call for other location
+	if len(strings.Split(name, "/")) > 3 && strings.Split(name, "/")[3] != location {
+		return nil, nil
+	}
+
+	resp, err := service.Projects.Locations.Environments.Get(name).Do()
+	if err != nil {
+		return nil, err
+	}
+
+	return resp, nil
+}
+
+//// TRANSFORM FUNCTIONS
+
+func composerEnvironmentTurbotData(ctx context.Context, d *transform.TransformData) (interface{}, error) {
+	env := d.HydrateItem.(*composer.Environment)
+
+	param := d.Param.(string)
+	splitEnv := strings.Split(env.Name, "/")
+
+	turbotData := map[string]interface{}{
+		"Project":  splitEnv[1],
+		"Location": splitEnv[3],
+		"SelfLink": "https://composer.googleapis.com/v1/" + env.Name,
+		"Akas":     []string{"gcp://composer.googleapis.com/" + env.Name},
+	}
+
+	return turbotData[param], nil
+}


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
Add passing integration test logs here
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
> select
  name,
  jsonb_path_query_array(web_server_network_access_control, '$.allowedIpRanges[*].value') as allowed_ip_ranges,
  location,
  project
from
  gcp_composer_environment
where
  web_server_network_access_control is not null;
+--------------------------------------------------------------+-----------------------+-------------+------------+
| name                                                         | allowed_ip_ranges     | location    | project    |
+--------------------------------------------------------------+-----------------------+-------------+------------+
| projects/parker-aaa/locations/us-central1/environments/test1 | ["0.0.0.0/0","::0/0"] | us-central1 | parker-aaa |
+--------------------------------------------------------------+-----------------------+-------------+------------+

```
</details>
