### PR TITLE
feat: add `ancestors` to `gcp_project` table

### DIFF
--- a/docs/tables/gcp_project.md
+++ b/docs/tables/gcp_project.md
@@ -56,3 +56,26 @@ select
 from
   gcp_project;
 ```
+
+### Get parent and organization ID for all projects
+Get the parent resource and organization ID across your various projects.
+
+```sql+postgres
+select
+  project_id,
+  parent ->> 'id' as parent_id,
+  parent ->> 'type' as parent_type,
+  case when jsonb_array_length(ancestors) > 1 then ancestors -> -1 -> 'resourceId' ->> 'id' else null end as organization_id
+from
+  gcp_project;
+```
+
+```sql+sqlite
+select
+  project_id,
+  parent ->> 'id' as parent_id,
+  parent ->> 'type' as parent_type,
+  case when json_array_length(ancestors) > 1 then ancestors -> -1 -> 'resourceId' ->> 'id' else null end as organization_id
+from
+  gcp_project;
+```


### PR DESCRIPTION
This PR adds an `ancestors` column to the `gcp_project` table.

This allows to discover the list of ancestors of a project in the resource hierarchy, from bottom to top.

# Integration test logs
<details>
  <summary>Logs</summary>
  
```
Add passing integration test logs here
```
</details>

# Example query _Get ancestors_ results
<details>
  <summary>Results</summary>
  
```
> select project_id, parent ->> 'id' as parent_id, parent ->> 'type' as parent_type, ancestors from gcp.gcp_project;
+---------------------+--------------+-------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| project_id          | parent_id    | parent_type | ancestors                                                                                                                                                                      |
+---------------------+--------------+-------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| myproject-012345678 | 111111111111 | folder      | [{"resourceId":{"id":"myproject-012345678","type":"project"}},{"resourceId":{"id":"111111111111","type":"folder"}},{"resourceId":{"id":"222222222222","type":"organization"}}] |
+---------------------+--------------+-------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

# Example query _Get organization id_ results
<details>
  <summary>Results</summary>
  
```
> select project_id, parent ->> 'id' as parent_id, parent ->> 'type' as parent_type, (case when jsonb_array_length(ancestors) > 1 then ancestors -> -1 -> 'resourceId' ->> 'id' else null end) as organization_id from gcp.gcp_project;

+---------------------+--------------+-------------+-----------------+
| project_id          | parent_id    | parent_type | organization_id |
+---------------------+--------------+-------------+-----------------+
| myproject-012345678 | 111111111111 | folder      | 222222222222    |
+---------------------+--------------+-------------+-----------------+
```
</details>
