### PR TITLE
feat!: allow retrieving all billing accounts and add billing_information column to gcp_project and gcp_organization_project tables

### DIFF
--- a/gcp/table_gcp_billing_account.go
+++ b/gcp/table_gcp_billing_account.go
@@ -72,6 +72,13 @@ func tableGcpBillingAccount(_ context.Context) *plugin.Table {
 				Type:        proto.ColumnType_STRING,
 				Transform:   transform.FromConstant("global"),
 			},
+			{
+				Name:        "project",
+				Description: ColumnDescriptionProject + " (Deprecated)",
+				Type:        proto.ColumnType_STRING,
+				Hydrate:     getProject,
+				Transform:   transform.FromValue(),
+			},
 		},
 	}
 }

--- a/gcp/table_gcp_organization_project.go
+++ b/gcp/table_gcp_organization_project.go
@@ -75,6 +75,13 @@ func tableGcpOrganizationProject(_ context.Context) *plugin.Table {
 				Hydrate:     getProjectAncestors,
 				Transform:   transform.FromValue(),
 			},
+			{
+				Name:        "billing_information",
+				Description: "The billing information of the project.",
+				Type:        proto.ColumnType_JSON,
+				Hydrate:     getProjectBillingInfo,
+				Transform:   transform.FromValue(),
+			},
 
 			// Steampipe standard columns
 			{


### PR DESCRIPTION
This is a breaking change, submitted as draft to initiate a discussion.

The rationale of this PR is that a billing account is not tied to a single project.
Without this change, all existing billing accounts cannot be discovered.

Edit: rebased on main so removed comment about what commits to review.

# Integration test logs
<details>
  <summary>Logs</summary>
  
```
Add passing integration test logs here
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
> select name, master_billing_account from gcp_billing_account order by master_billing_account, name
+----------------------+--------------------------------------+
| name                 | master_billing_account               |
+----------------------+--------------------------------------+
| 00D010-012345-000000 |                                      |
| 011C92-012345-111111 |                                      |
| 016C27-012345-222222 |                                      |
| 01BDFD-012345-333333 |                                      |
| 01C328-012345-444444 |                                      |
| 0024B1-012345-012345 | billingAccounts/00D010-012345-000000 |
| 010892-012345-012345 | billingAccounts/00D010-012345-000000 |
| 0109E7-012345-012345 | billingAccounts/00D010-012345-000000 |
| 010FA8-012345-012345 | billingAccounts/00D010-012345-000000 |
| 0110A7-012345-012345 | billingAccounts/00D010-012345-000000 |
| 0112CD-012345-012345 | billingAccounts/00D010-012345-000000 |
| 01245D-012345-012345 | billingAccounts/00D010-012345-000000 |
| 0128B9-012345-012345 | billingAccounts/00D010-012345-000000 |
| 012DD3-012345-012345 | billingAccounts/00D010-012345-000000 |
| 0130FA-012345-012345 | billingAccounts/00D010-012345-000000 |
| 013522-012345-012345 | billingAccounts/00D010-012345-000000 |
| 0145D3-012345-012345 | billingAccounts/00D010-012345-000000 |
| 014F17-012345-012345 | billingAccounts/00D010-012345-000000 |
| 015116-012345-012345 | billingAccounts/00D010-012345-000000 |
| 0151FE-012345-012345 | billingAccounts/00D010-012345-000000 |
| 015574-012345-012345 | billingAccounts/00D010-012345-000000 |
| 016C91-012345-012345 | billingAccounts/00D010-012345-000000 |
| 017047-012345-012345 | billingAccounts/00D010-012345-000000 |
| 0180B0-012345-012345 | billingAccounts/00D010-012345-000000 |
| 018C5C-012345-012345 | billingAccounts/00D010-012345-000000 |
| 018D0A-012345-012345 | billingAccounts/00D010-012345-000000 |
| 01A1D3-012345-012345 | billingAccounts/00D010-012345-000000 |
| 01BAE2-012345-012345 | billingAccounts/00D010-012345-000000 |
| 01C9B8-012345-012345 | billingAccounts/00D010-012345-000000 |
| 01C9CA-012345-012345 | billingAccounts/00D010-012345-000000 |
| 01DE4B-012345-012345 | billingAccounts/00D010-012345-000000 |
| 01E25A-012345-012345 | billingAccounts/00D010-012345-000000 |
| 01E62F-012345-012345 | billingAccounts/00D010-012345-000000 |
| 014D64-012345-012345 | billingAccounts/01F621-012345-555555 |
| 016524-012345-012345 | billingAccounts/01F621-012345-555555 |
| 01DE7B-012345-012345 | billingAccounts/01F621-012345-555555 |
| 01FD31-012345-012345 | billingAccounts/01F621-012345-555555 |
+----------------------+--------------------------------------+

```
</details>
