### PR TITLE
kubernetes_node_pool: fix fetching node-pool when AutoPilot is not available

### DIFF
--- a/gcp/table_gcp_kubernetes_node_pool.go
+++ b/gcp/table_gcp_kubernetes_node_pool.go
@@ -151,7 +151,7 @@ func listKubernetesNodePools(ctx context.Context, d *plugin.QueryData, h *plugin
 	// This operation is not allowed if the cluster has Autopilot Enabled.
 	// We are getting the error Error: gcp: googleapi: Error 400: Autopilot node pools cannot be accessed or modified.
 
-	if cluster.Autopilot.Enabled {
+	if cluster.Autopilot != nil && cluster.Autopilot.Enabled {
 		return nil, nil
 	}
 


### PR DESCRIPTION
When AutoPilot is not available (not *disabled*), `cluster.Autopilot` is `nil` and `cluster.Autopilot.Enabled` crashes the plugin with a `invalid memory address or nil pointer dereference` error.

# Integration test logs
<details>
  <summary>Logs</summary>

</details>

# Example query results
<details>
  <summary>Results</summary>

Before the fix:


```
> select name, autopilot_enabled from gcp_kubernetes_cluster;
+-----------+-------------------+
| name      | autopilot_enabled |
+-----------+-------------------+
| cluster-3 | false             |
| cluster-4 | false             |
| cluster-1 | <null>            |
| cluster-2 | false             |
+-----------+-------------------+
>
> select cluster_name, name from gcp_kubernetes_node_pool where cluster_name = 'cluster-4' order by name limit 1;

Error: test_gcp: runtime error: invalid memory address or nil pointer dereference (SQLSTATE HV000)

+--------------+------+
| cluster_name | name |
+--------------+------+
+--------------+------+
>
> select cluster_name, name from gcp_kubernetes_node_pool where cluster_name = 'cluster-3' order by name limit 1;

Error: test_gcp: runtime error: invalid memory address or nil pointer dereference (SQLSTATE HV000)

+--------------+------+
| cluster_name | name |
+--------------+------+
+--------------+------+
>
```

After the fix:

```
> select name, autopilot_enabled from gcp_kubernetes_cluster;
+-----------+-------------------+
| name      | autopilot_enabled |
+-----------+-------------------+
| cluster-3 | false             |
| cluster-4 | false             |
| cluster-1 | <null>            |
| cluster-2 | false             |
+-----------+-------------------+
>
> select cluster_name, name from gcp_kubernetes_node_pool where cluster_name = 'cluster-4' order by name limit 1;
+---------------+-------------+
| cluster_name  | name        |
+---------------+-------------+
| cluster-4     | node-pool-1 |
+---------------+-------------+
>
> select cluster_name, name from gcp_kubernetes_node_pool where cluster_name = 'cluster-3' order by name limit 1;
+---------------+-------------+
| cluster_name  | name        |
+---------------+-------------+
| cluster-3     | node-pool-1 |
+---------------+-------------+
>
```
</details>
