### PR TITLE
fix: instances column of gcp_compute_instance_group errors for regional groups

### DIFF
--- a/gcp/table_gcp_compute_instance_group.go
+++ b/gcp/table_gcp_compute_instance_group.go
@@ -259,14 +259,23 @@ func getComputeInstanceGroupInstances(ctx context.Context, d *plugin.QueryData, 
 		return nil, err
 	}
 
-	resp, err := service.InstanceGroups.ListInstances(project, getLastPathElement(types.SafeString(instanceGroup.Zone)), instanceGroup.Name, &compute.InstanceGroupsListInstancesRequest{}).Do()
-
-	if err != nil {
-		plugin.Logger(ctx).Error("gcp_compute_instance_group.getComputeInstanceGroupInstances", "api_err", err)
-		return nil, err
+	// Regional instance groups do not have any zone specified but a region instead,
+	// and querying their instances must be done with the regional endpoint
+	if instanceGroup.Zone == "" {
+		resp, err := service.RegionInstanceGroups.ListInstances(project, getLastPathElement(types.SafeString(instanceGroup.Region)), instanceGroup.Name, &compute.RegionInstanceGroupsListInstancesRequest{}).Do()
+		if err != nil {
+			plugin.Logger(ctx).Error("gcp_compute_instance_group.getComputeInstanceGroupInstances", "api_err", err)
+			return nil, err
+		}
+		return &resp.Items, nil
+	} else {
+		resp, err := service.InstanceGroups.ListInstances(project, getLastPathElement(types.SafeString(instanceGroup.Zone)), instanceGroup.Name, &compute.InstanceGroupsListInstancesRequest{}).Do()
+		if err != nil {
+			plugin.Logger(ctx).Error("gcp_compute_instance_group.getComputeInstanceGroupInstances", "api_err", err)
+			return nil, err
+		}
+		return &resp.Items, nil
 	}
-
-	return &resp.Items, nil
 }
 
 //// TRANSFORM FUNCTIONS


### PR DESCRIPTION
Without this change, the `instances` column of the `gcp_compute_instance_group` table triggers an error for regional instance groups:
```
# steampipe query
Welcome to Steampipe v0.24.2
For more information, type .help
> select name, instances, region_name, zone_name from gcp_compute_instance_group

Error: gcp: googleapi: Error 400: Invalid value for field 'zone': ''. Must be a match of regex '(?:[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?)', invalid (SQLSTATE HV000)

+------------------------------------------------------+-----------+-------------+----------------+
| name                                                 | instances | region_name | zone_name      |
+------------------------------------------------------+-----------+-------------+----------------+
| pdecat-managed-instance-group-stateful-zonal-single  | <null>    |             | europe-west9-a |
| pdecat-managed-instance-group-stateless-zonal-single | <null>    |             | europe-west9-a |
| pdecat-unmanaged-instance-group-zonal-single         | <null>    |             | europe-west9-a |
+------------------------------------------------------+-----------+-------------+----------------+
```

With this change:
```
# steampipe query
Welcome to Steampipe v0.24.2
For more information, type .help
> select name, instances, region_name, zone_name from gcp_compute_instance_group
+--------------------------------------------------------+-----------+--------------+----------------+
| name                                                   | instances | region_name  | zone_name      |
+--------------------------------------------------------+-----------+--------------+----------------+
| pdecat-managed-instance-group-stateless-zonal-single   | <null>    |              | europe-west9-a |
| pdecat-unmanaged-instance-group-zonal-single           | <null>    |              | europe-west9-a |
| pdecat-managed-instance-group-stateful-zonal-multiple  | <null>    | europe-west9 |                |
| pdecat-managed-instance-group-stateful-zonal-single    | <null>    |              | europe-west9-a |
| pdecat-managed-instance-group-stateless-zonal-multiple | <null>    | europe-west9 |                |
+--------------------------------------------------------+-----------+--------------+----------------+
```

Note: instances values are `null` because all my test instance groups have 0 instances.

# Integration test logs
<details>
  <summary>Logs</summary>
  
```
Add passing integration test logs here
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
Add example SQL query results here (please include the input queries as well)
```
</details>
