### PR TITLE
feat: add `labels` and `tags` columns to `gcp_compute_global_forwarding_rule` table

### DIFF
--- a/gcp/table_gcp_compute_global_forwarding_rule.go
+++ b/gcp/table_gcp_compute_global_forwarding_rule.go
@@ -160,6 +160,11 @@ func tableGcpComputeGlobalForwardingRule(ctx context.Context) *plugin.Table {
 				Description: "A list of ports can be configured.",
 				Type:        proto.ColumnType_JSON,
 			},
+			{
+				Name:        "labels",
+				Description: "A list of labels attached to this resource.",
+				Type:        proto.ColumnType_JSON,
+			},
 
 			// standard steampipe columns
 			{

--- a/gcp/table_gcp_compute_global_forwarding_rule.go
+++ b/gcp/table_gcp_compute_global_forwarding_rule.go
@@ -168,6 +168,12 @@ func tableGcpComputeGlobalForwardingRule(ctx context.Context) *plugin.Table {
 
 			// standard steampipe columns
 			{
+				Name:        "tags",
+				Description: ColumnDescriptionTags,
+				Type:        proto.ColumnType_JSON,
+				Transform:   transform.FromField("Labels"),
+			},
+			{
 				Name:        "title",
 				Description: ColumnDescriptionTitle,
 				Type:        proto.ColumnType_STRING,


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
Add passing integration test logs here
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
> select md5(name) as name, labels -> 'deployed_by', tags -> 'deployed_by' from gcp_compute_global_forwarding_rule where labels is not null limit 1
+----------------------------------+-------------+-------------+
| name                             | ?column?    | ?column?    |
+----------------------------------+-------------+-------------+
| f2811506722a00854dc34817929e5c1e | "terraform" | "terraform" |
+----------------------------------+-------------+-------------+

```
</details>
