### PR TITLE
Fixed the error unsupported region northamerica-south1 for the table gcp_cloud_run_service closes #696

### DIFF
--- a/gcp/cloud_run_location_list.go
+++ b/gcp/cloud_run_location_list.go
@@ -43,7 +43,6 @@ func BuildCloudRunLocationList(ctx context.Context, d *plugin.QueryData) []map[s
 	// validate location list
 	matrix := make([]map[string]interface{}, len(resp.Locations))
 	for i, location := range resp.Locations {
-		plugin.Logger(ctx).Error("Service location:", location.LocationId )
 		matrix[i] = map[string]interface{}{matrixKeyLocation: location.LocationId}
 	}
 	d.ConnectionManager.Cache.Set(locationCacheKey, matrix)

--- a/gcp/cloud_run_location_list.go
+++ b/gcp/cloud_run_location_list.go
@@ -1,0 +1,50 @@
+package gcp
+
+import (
+	"context"
+
+	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
+)
+
+// Based on the available documentation, there is no indication that the Cloud Run Admin API v1 supports specific locations that v2 does not.
+// Both API versions are designed to operate across all regions where Cloud Run is available.
+// The primary differences between v1 and v2 pertain to API design and compatibility, rather than regional support.
+
+// https://cloud.google.com/run/docs/locations
+// BuildCloudRunLocationList :: return a list of matrix items, one per region specified
+func BuildCloudRunLocationList(ctx context.Context, d *plugin.QueryData) []map[string]interface{} {
+
+	// have we already created and cached the locations?
+	locationCacheKey := "CloudRunLocation"
+	if cachedData, ok := d.ConnectionManager.Cache.Get(locationCacheKey); ok {
+		plugin.Logger(ctx).Trace("listlocationDetails:", cachedData.([]map[string]interface{}))
+		return cachedData.([]map[string]interface{})
+	}
+
+	// Create Service Connection
+	service, err := CloudRunServiceV1(ctx, d)
+	if err != nil {
+		return nil
+	}
+
+	// Get project details
+	projectData, err := activeProject(ctx, d)
+	if err != nil {
+		return nil
+	}
+	project := projectData.Project
+
+
+	resp, err := service.Projects.Locations.List("projects/" + project).Do()
+	if err != nil {
+		return nil
+	}
+	// validate location list
+	matrix := make([]map[string]interface{}, len(resp.Locations))
+	for i, location := range resp.Locations {
+		plugin.Logger(ctx).Error("Service location:", location.LocationId )
+		matrix[i] = map[string]interface{}{matrixKeyLocation: location.LocationId}
+	}
+	d.ConnectionManager.Cache.Set(locationCacheKey, matrix)
+	return matrix
+}

--- a/gcp/cloud_run_location_list.go
+++ b/gcp/cloud_run_location_list.go
@@ -9,6 +9,7 @@ import (
 // Based on the available documentation, there is no indication that the Cloud Run Admin API v1 supports specific locations that v2 does not.
 // Both API versions are designed to operate across all regions where Cloud Run is available.
 // The primary differences between v1 and v2 pertain to API design and compatibility, rather than regional support.
+// Using the Cloud Run V1 API to list supported regions will not have any negative impact, even though the Cloud Run V2 API is used in the gcp_cloud_run_* tables for building the region matrix. The region data remains consistent across both API versions, ensuring accurate coverage without affecting functionality.
 
 // https://cloud.google.com/run/docs/locations
 // BuildCloudRunLocationList :: return a list of matrix items, one per region specified

--- a/gcp/service.go
+++ b/gcp/service.go
@@ -34,6 +34,7 @@ import (
 	"google.golang.org/api/monitoring/v3"
 	"google.golang.org/api/option"
 	"google.golang.org/api/pubsub/v1"
+	run1 "google.golang.org/api/run/v1"
 	"google.golang.org/api/run/v2"
 	"google.golang.org/api/secretmanager/v1"
 	"google.golang.org/api/serviceusage/v1"
@@ -344,6 +345,27 @@ func CloudRunService(ctx context.Context, d *plugin.QueryData) (*run.Service, er
 
 	// so it was not in cache - create service
 	svc, err := run.NewService(ctx, opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	d.ConnectionManager.Cache.Set(serviceCacheKey, svc)
+	return svc, nil
+}
+
+// CloudRunService returns the service connection for GCP Cloud Run service
+func CloudRunServiceV1(ctx context.Context, d *plugin.QueryData) (*run1.APIService, error) {
+	// have we already created and cached the service?
+	serviceCacheKey := "CloudRunServiceV1"
+	if cachedData, ok := d.ConnectionManager.Cache.Get(serviceCacheKey); ok {
+		return cachedData.(*run1.APIService), nil
+	}
+
+	// To get config arguments from plugin config file
+	opts := setSessionConfig(ctx, d.Connection)
+
+	// so it was not in cache - create service
+	svc, err := run1.NewService(ctx, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/gcp/table_gcp_cloud_run_service.go
+++ b/gcp/table_gcp_cloud_run_service.go
@@ -31,7 +31,7 @@ func tableGcpCloudRunService(ctx context.Context) *plugin.Table {
 				},
 			},
 		},
-		GetMatrixItemFunc: BuildComputeLocationList,
+		GetMatrixItemFunc: BuildCloudRunLocationList,
 		Columns: []*plugin.Column{
 			{
 				Name:        "name",


### PR DESCRIPTION

# Integration test logs
<details>
  <summary>Logs</summary>
  
```
N/A
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
> select * from gcp_cloud_run_service;

+--------+--------+----------------+-------------+---------------------------+-------------+-------------------+------------------------------------------------------------------------------------------------+-------------+------------+---------------------+----------->
| name   | client | client_version | description | create_time               | delete_time | creator           | etag                                                                                           | expire_time | generation | ingress             | self_link >
+--------+--------+----------------+-------------+---------------------------+-------------+-------------------+------------------------------------------------------------------------------------------------+-------------+------------+---------------------+----------->
| test31 | gcloud | 502.0.0        |             | 2025-01-06T13:03:28+05:30 | <null>      | jostsd@hsuebn.com | "CJem7rsGENjV8HA/cHJvamVjdHMvcGFya2VyLWFhYS9sb2NhdGlvbnMvdXMtY2VudHJhbDEvc2VydmljZXMvdGVzdDMx" | <null>      | 5          | INGRESS_TRAFFIC_ALL | https://ru>
+--------+--------+----------------+-------------+---------------------------+-------------+-------------------+------------------------------------------------------------------------------------------------+-------------+------------+---------------------+----------->

```
</details>
