### PR TITLE
Fix the gcp_cloud_run_job table to use the correct build matrix function for generating the location list Closes #721

### DIFF
--- a/gcp/table_gcp_cloud_run_job.go
+++ b/gcp/table_gcp_cloud_run_job.go
@@ -31,7 +31,7 @@ func tableGcpCloudRunJob(ctx context.Context) *plugin.Table {
 				},
 			},
 		},
-		GetMatrixItemFunc: BuildComputeLocationList,
+		GetMatrixItemFunc: BuildCloudRunLocationList,
 		Columns: []*plugin.Column{
 			{
 				Name:        "name",


### PR DESCRIPTION

# Integration test logs
<details>
  <summary>Logs</summary>
  
```
N/A
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
> select * from gcp_cloud_run_job;
+--------+---------------+----------------+---------------------------+-------------+---------+--------------------------------------------------------------------------------------------+-----------------+-------------+------------+------------------------------------>
| name   | client        | client_version | create_time               | delete_time | creator | etag                                                                                       | execution_count | expire_time | generation | self_link                          >
+--------+---------------+----------------+---------------------------+-------------+---------+--------------------------------------------------------------------------------------------+-----------------+-------------+------------+------------------------------------>
| testme | cloud-console |                | 2025-02-11T16:24:18+05:30 | <null>      |         | "CNrYrL0GEMiNrdkB/cHJvamVjdHMvcGFya2VyLWFhYS9sb2NhdGlvbnMvdXMtY2VudHJhbDEvam9icy90ZXN0bWU" | 0               | <null>      | 1          | https://run.googleapis.com/v2/proje>
+--------+---------------+----------------+---------------------------+-------------+---------+--------------------------------------------------------------------------------------------+-----------------+-------------+------------+------------------------------------>
```
</details>
