### PR TITLE
Add table gcp_compute_security_policy closes #761

### DIFF
--- a/docs/tables/gcp_compute_security_policy.md
+++ b/docs/tables/gcp_compute_security_policy.md
@@ -1,6 +1,7 @@
 ---
 title: "Steampipe Table: gcp_compute_security_policy - Query Google Cloud Armor Security Policies using SQL"
 description: "Allows users to query Google Cloud Armor Security Policies, providing insights into policy details, rules, and configuration."
+folder: "Compute"
 ---
 
 # Table: gcp_compute_security_policy

--- a/docs/tables/gcp_compute_security_policy.md
+++ b/docs/tables/gcp_compute_security_policy.md
@@ -12,9 +12,17 @@ Google Cloud Armor Security Policies protect your applications from DDoS and app
 
 The `gcp_compute_security_policy` table provides insights into Cloud Armor security policies for your GCP projects.
 
-### Examples
+**Important Notes:**
+- This table supports optional quals. Queries with optional quals are optimised to use security policy filters. Optional quals are supported for the following columns:
+  - `id`
+  - `type`
+  - `description`
+  - `self_link`
+  - `filter`: For additional details regarding the filter string, please refer to the documentation at https://cloud.google.com/compute/docs/reference/rest/v1/securityPolicies/list?filter#query-parameters.
 
-#### List all security policies
+## Examples
+
+### List all security policies
 List all Google Cloud Armor security policies in your GCP projects, including their names, IDs, descriptions, and self links.
 
 ```sql+postgres
@@ -37,7 +45,7 @@ from
   gcp_compute_security_policy;
 ```
 
-#### Get a security policy by name
+### Get a security policy by name
 Retrieve details for a specific security policy by its name, including its rules, labels, and associated project.
 
 ```sql+postgres
@@ -68,7 +76,7 @@ where
   name = 'my-security-policy';
 ```
 
-#### List all rules for each security policy
+### List all rules for each security policy
 Show the rules defined for each security policy, helping you review policy configurations across your environment.
 
 ```sql+postgres
@@ -87,7 +95,7 @@ from
   gcp_compute_security_policy;
 ```
 
-#### Show all policies with adaptive protection enabled
+### Show all policies with adaptive protection enabled
 Identify security policies that have adaptive protection enabled, which helps protect against advanced DDoS attacks.
 
 ```sql+postgres
@@ -108,4 +116,33 @@ from
   gcp_compute_security_policy
 where
   json_extract(adaptive_protection_config, '$.layer7DdosDefenseConfig.enable') = 'true';
+```
+
+### Filter security policies by ID and description 
+Use the filter parameter to query security policies with specific criteria. This example shows how to filter by ID and description.
+
+```sql+postgres
+select
+  name,
+  id,
+  creation_timestamp,
+  description,
+  self_link
+from
+  gcp_compute_security_policy
+where
+  filter = 'id = 4811866613213140474 AND description = "Default security policy for: tet5s"';
+```
+
+```sql+sqlite
+select
+  name,
+  id,
+  creation_timestamp,
+  description,
+  self_link
+from
+  gcp_compute_security_policy
+where
+  filter = 'id = 4811866613213140474 AND description = "Default security policy for: tet5s"';
 ```

--- a/docs/tables/gcp_compute_security_policy.md
+++ b/docs/tables/gcp_compute_security_policy.md
@@ -1,0 +1,72 @@
+---
+title: "Steampipe Table: gcp_compute_security_policy - Query Google Cloud Armor Security Policies using SQL"
+description: "Allows users to query Google Cloud Armor Security Policies, providing insights into policy details, rules, and configuration."
+folder: "Compute"
+---
+
+# Table: gcp_compute_security_policy
+
+Google Cloud Armor Security Policies protect your applications from DDoS and application attacks. This table lets you query policy details, rules, and configuration.
+
+## Table Usage Guide
+
+The `gcp_compute_security_policy` table provides insights into Cloud Armor security policies for your GCP projects.
+
+### Examples
+
+#### List all security policies
+```sql
+select
+  name,
+  id,
+  description,
+  self_link
+from
+  gcp_compute_security_policy;
+```
+
+#### Get a security policy by name
+```sql
+select
+  name,
+  id,
+  description,
+  rules,
+  labels,
+  project
+from
+  gcp_compute_security_policy
+where
+  name = 'my-security-policy';
+```
+
+#### List all rules for each security policy
+```sql
+select
+  name,
+  rules
+from
+  gcp_compute_security_policy;
+```
+
+#### Find security policies with a specific label
+```sql
+select
+  name,
+  labels
+from
+  gcp_compute_security_policy
+where
+  labels ->> 'env' = 'prod';
+```
+
+#### Show all policies with adaptive protection enabled
+```sql
+select
+  name,
+  adaptive_protection_config
+from
+  gcp_compute_security_policy
+where
+  adaptive_protection_config -> 'layer7DdosDefenseConfig' ->> 'enable' = 'true';
+```

--- a/docs/tables/gcp_compute_security_policy.md
+++ b/docs/tables/gcp_compute_security_policy.md
@@ -1,7 +1,6 @@
 ---
 title: "Steampipe Table: gcp_compute_security_policy - Query Google Cloud Armor Security Policies using SQL"
 description: "Allows users to query Google Cloud Armor Security Policies, providing insights into policy details, rules, and configuration."
-folder: "Compute"
 ---
 
 # Table: gcp_compute_security_policy
@@ -15,7 +14,19 @@ The `gcp_compute_security_policy` table provides insights into Cloud Armor secur
 ### Examples
 
 #### List all security policies
-```sql
+List all Google Cloud Armor security policies in your GCP projects, including their names, IDs, descriptions, and self links.
+
+```sql+postgres
+select
+  name,
+  id,
+  description,
+  self_link
+from
+  gcp_compute_security_policy;
+```
+
+```sql+sqlite
 select
   name,
   id,
@@ -26,7 +37,23 @@ from
 ```
 
 #### Get a security policy by name
-```sql
+Retrieve details for a specific security policy by its name, including its rules, labels, and associated project.
+
+```sql+postgres
+select
+  name,
+  id,
+  description,
+  rules,
+  labels,
+  project
+from
+  gcp_compute_security_policy
+where
+  name = 'my-security-policy';
+```
+
+```sql+sqlite
 select
   name,
   id,
@@ -41,7 +68,9 @@ where
 ```
 
 #### List all rules for each security policy
-```sql
+Show the rules defined for each security policy, helping you review policy configurations across your environment.
+
+```sql+postgres
 select
   name,
   rules
@@ -49,19 +78,18 @@ from
   gcp_compute_security_policy;
 ```
 
-#### Find security policies with a specific label
-```sql
+```sql+sqlite
 select
   name,
-  labels
+  rules
 from
-  gcp_compute_security_policy
-where
-  labels ->> 'env' = 'prod';
+  gcp_compute_security_policy;
 ```
 
 #### Show all policies with adaptive protection enabled
-```sql
+Identify security policies that have adaptive protection enabled, which helps protect against advanced DDoS attacks.
+
+```sql+postgres
 select
   name,
   adaptive_protection_config
@@ -69,4 +97,14 @@ from
   gcp_compute_security_policy
 where
   adaptive_protection_config -> 'layer7DdosDefenseConfig' ->> 'enable' = 'true';
+```
+
+```sql+sqlite
+select
+  name,
+  adaptive_protection_config
+from
+  gcp_compute_security_policy
+where
+  json_extract(adaptive_protection_config, '$.layer7DdosDefenseConfig.enable') = 'true';
 ```

--- a/gcp-test/tests/gcp_compute_security_policy/test-get-expected.json
+++ b/gcp-test/tests/gcp_compute_security_policy/test-get-expected.json
@@ -1,0 +1,28 @@
+[
+  {
+    "description": "Test security policy for validation.",
+    "fingerprint": "{{ output.fingerprint.value }}",
+    "location": "global",
+    "name": "{{ resourceName }}",
+    "project": "{{ output.project_id.value }}",
+    "rules": [
+      {
+        "action": "allow",
+        "description": "default rule",
+        "headerAction": {},
+        "kind": "compute#securityPolicyRule",
+        "match": {
+          "config": {
+            "srcIpRanges": [
+              "*"
+            ]
+          },
+          "versionedExpr": "SRC_IPS_V1"
+        },
+        "priority": 2147483647
+      }
+    ],
+    "self_link": "{{ output.self_link.value }}",
+    "type": "CLOUD_ARMOR"
+  }
+]

--- a/gcp-test/tests/gcp_compute_security_policy/test-get-query.sql
+++ b/gcp-test/tests/gcp_compute_security_policy/test-get-query.sql
@@ -1,0 +1,3 @@
+select name, description, self_link, fingerprint, type, rules, project, location
+from gcp_compute_security_policy
+where name = '{{ resourceName }}';

--- a/gcp-test/tests/gcp_compute_security_policy/test-list-expected.json
+++ b/gcp-test/tests/gcp_compute_security_policy/test-list-expected.json
@@ -1,0 +1,8 @@
+[
+  {
+    "description": "Test security policy for validation.",
+    "fingerprint": "{{ output.fingerprint.value }}",
+    "name": "{{ resourceName }}",
+    "self_link": "{{ output.self_link.value }}"
+  }
+]

--- a/gcp-test/tests/gcp_compute_security_policy/test-list-query.sql
+++ b/gcp-test/tests/gcp_compute_security_policy/test-list-query.sql
@@ -1,0 +1,1 @@
+select name, fingerprint, description, self_link from gcp_compute_security_policy where title = '{{ resourceName }}'

--- a/gcp-test/tests/gcp_compute_security_policy/variables.tf
+++ b/gcp-test/tests/gcp_compute_security_policy/variables.tf
@@ -1,0 +1,73 @@
+
+variable "resource_name" {
+  type        = string
+  default     = "turbot-test-20200125-create-update"
+  description = "Name of the resource used throughout the test."
+}
+
+variable "gcp_project" {
+  type        = string
+  default     = "nagraj-aaa"
+  description = "GCP project used for the test."
+}
+
+variable "gcp_region" {
+  type        = string
+  default     = "us-east1"
+  description = "GCP region used for the test."
+}
+
+variable "gcp_zone" {
+  type    = string
+  default = "us-east1-b"
+}
+
+provider "google" {
+  project = var.gcp_project
+  region  = var.gcp_region
+  zone    = var.gcp_zone
+}
+
+data "google_client_config" "current" {}
+
+data "null_data_source" "resource" {
+  inputs = {
+    scope = "gcp://cloudresourcemanager.googleapis.com/projects/${data.google_client_config.current.project}"
+  }
+}
+
+resource "google_compute_security_policy" "named_test_resource" {
+  name        = var.resource_name
+  description = "Test security policy for validation."
+  rule {
+    action   = "allow"
+    priority = 2147483647
+    match {
+      versioned_expr = "SRC_IPS_V1"
+      config {
+        src_ip_ranges = ["*"]
+      }
+    }
+    description = "default rule"
+  }
+}
+
+output "resource_name" {
+  value = var.resource_name
+}
+
+output "resource_id" {
+  value = google_compute_security_policy.named_test_resource.id
+}
+
+output "self_link" {
+  value = google_compute_security_policy.named_test_resource.self_link
+}
+
+output "fingerprint" {
+  value = google_compute_security_policy.named_test_resource.fingerprint
+}
+
+output "project_id" {
+  value = var.gcp_project
+}

--- a/gcp-test/tint.js
+++ b/gcp-test/tint.js
@@ -384,7 +384,7 @@ const _runGraphqlQuery = function (test, query) {
   return new Promise((resolve, reject) => {
     try {
       var queryTmp = _renderToTmp(test, query.query);
-      var variablesTmp = _renderToTmp(test, query.variables, {});
+      // var variablesTmp = _renderToTmp(test, query.variables, {});
       var expectedTmp = _renderToTmp(test, query.expected);
     } catch (e) {
       console.log(chalk.red(`Template Error: ${e.sourcePath}`));

--- a/gcp/plugin.go
+++ b/gcp/plugin.go
@@ -126,6 +126,7 @@ func Plugin(ctx context.Context) *plugin.Plugin {
 			"gcp_compute_router":                                      tableGcpComputeRouter(ctx),
 			"gcp_compute_snapshot":                                    tableGcpComputeSnapshot(ctx),
 			"gcp_compute_ssl_policy":                                  tableGcpComputeSslPolicy(ctx),
+			"gcp_compute_security_policy":                             tableGcpComputeSecurityPolicy(ctx),
 			"gcp_compute_subnetwork":                                  tableGcpComputeSubnetwork(ctx),
 			"gcp_compute_target_https_proxy":                          tableGcpComputeTargetHttpsProxy(ctx),
 			"gcp_compute_target_pool":                                 tableGcpComputeTargetPool(ctx),

--- a/gcp/table_gcp_compute_security_policy.go
+++ b/gcp/table_gcp_compute_security_policy.go
@@ -1,0 +1,133 @@
+package gcp
+
+import (
+	"context"
+	"strings"
+
+	"github.com/turbot/go-kit/types"
+	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
+	"google.golang.org/api/compute/v1"
+)
+
+//// TABLE DEFINITION
+
+func tableGcpComputeSecurityPolicy(ctx context.Context) *plugin.Table {
+	return &plugin.Table{
+		Name:        "gcp_compute_security_policy",
+		Description: "Google Cloud Armor Security Policy",
+		Get: &plugin.GetConfig{
+			KeyColumns: plugin.SingleColumn("name"),
+			Hydrate:    getGcpComputeSecurityPolicy,
+		},
+		List: &plugin.ListConfig{
+			Hydrate: listGcpComputeSecurityPolicies,
+		},
+		Columns: []*plugin.Column{
+			{Name: "name", Type: proto.ColumnType_STRING, Description: "The name of the security policy."},
+			{Name: "id", Type: proto.ColumnType_INT, Description: "The unique identifier for the resource."},
+			{Name: "description", Type: proto.ColumnType_STRING, Description: "An optional description of this resource."},
+			{Name: "self_link", Type: proto.ColumnType_STRING, Description: "The fully-qualified URL linking back to the resource."},
+			{Name: "fingerprint", Type: proto.ColumnType_STRING, Description: "Fingerprint of this resource. A hash of the contents stored in this object."},
+			{Name: "type", Type: proto.ColumnType_STRING, Description: "The type of the security policy."},
+			{Name: "rules", Type: proto.ColumnType_JSON, Description: "The set of rules that belong to this policy."},
+			{Name: "adaptive_protection_config", Type: proto.ColumnType_JSON, Description: "Configuration for adaptive protection."},
+			{Name: "advanced_options_config", Type: proto.ColumnType_JSON, Description: "Advanced options configuration."},
+			{Name: "recaptcha_options_config", Type: proto.ColumnType_JSON, Description: "reCAPTCHA options configuration."},
+			{Name: "labels", Type: proto.ColumnType_JSON, Description: "Labels to apply to this security policy."},
+			{Name: "label_fingerprint", Type: proto.ColumnType_STRING, Description: "Fingerprint of the labels."},
+			{Name: "project", Type: proto.ColumnType_STRING, Transform: transform.FromP(securityPolicyTurbotData, "Project"), Description: "The GCP Project ID."},
+			{Name: "location", Type: proto.ColumnType_STRING, Transform: transform.FromConstant("global"), Description: "The location for the resource. Always 'global' for security policies."},
+			{Name: "akas", Type: proto.ColumnType_JSON, Transform: transform.FromP(securityPolicyTurbotData, "Akas"), Description: "Array of globally unique identifier strings (also known as 'also known as' or 'akas')."},
+			{Name: "title", Type: proto.ColumnType_STRING, Transform: transform.FromField("Name"), Description: "Title of the resource."},
+		},
+	}
+}
+
+//// LIST FUNCTION
+
+func listGcpComputeSecurityPolicies(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+	plugin.Logger(ctx).Trace("listGcpComputeSecurityPolicies")
+
+	// Create Service Connection
+	service, err := ComputeService(ctx, d)
+	if err != nil {
+		return nil, err
+	}
+
+	// Get project details
+	projectId, err := getProject(ctx, d, h)
+	if err != nil {
+		return nil, err
+	}
+	project := projectId.(string)
+
+	// Set page size to 500 or query limit if lower
+	pageSize := types.Int64(500)
+	limit := d.QueryContext.Limit
+	if d.QueryContext.Limit != nil {
+		if *limit < *pageSize {
+			pageSize = limit
+		}
+	}
+
+	resp := service.SecurityPolicies.List(project).MaxResults(*pageSize)
+	if err := resp.Pages(ctx, func(page *compute.SecurityPolicyList) error {
+		// apply rate limiting
+		d.WaitForListRateLimit(ctx)
+		for _, policy := range page.Items {
+			d.StreamListItem(ctx, policy)
+			if d.RowsRemaining(ctx) == 0 {
+				return nil
+			}
+		}
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+	return nil, nil
+}
+
+//// HYDRATE FUNCTIONS
+
+func getGcpComputeSecurityPolicy(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+	service, err := ComputeService(ctx, d)
+	if err != nil {
+		return nil, err
+	}
+
+	// Get project details
+	projectId, err := getProject(ctx, d, h)
+	if err != nil {
+		return nil, err
+	}
+	project := projectId.(string)
+	name := d.EqualsQualString("name")
+
+	// Return nil, if no input provided
+	if name == "" {
+		return nil, nil
+	}
+	policy, err := service.SecurityPolicies.Get(project, name).Do()
+	if err != nil {
+		return nil, err
+	}
+	return policy, nil
+}
+
+func securityPolicyTurbotData(_ context.Context, d *transform.TransformData) (interface{}, error) {
+	data := d.HydrateItem.(*compute.SecurityPolicy)
+	project := ""
+	if data.SelfLink != "" {
+		parts := strings.Split(data.SelfLink, "/")
+		if len(parts) > 6 {
+			project = parts[6]
+		}
+	}
+	turbotData := map[string]interface{}{
+		"Project": project,
+		"Akas":    []string{"gcp://compute.googleapis.com" + data.SelfLink},
+	}
+	return turbotData[d.Param.(string)], nil
+}

--- a/gcp/table_gcp_compute_security_policy.go
+++ b/gcp/table_gcp_compute_security_policy.go
@@ -58,14 +58,14 @@ func tableGcpComputeSecurityPolicy(ctx context.Context) *plugin.Table {
 			{Name: "akas", Type: proto.ColumnType_JSON, Transform: transform.FromP(securityPolicyTurbotData, "Akas"), Description: ColumnDescriptionAkas},
 			{Name: "tags", Type: proto.ColumnType_JSON, Transform: transform.FromField("Labels"), Description: ColumnDescriptionTags},
 
-			// standard gcp columns
+			// standard GCP columns
 			{Name: "project", Type: proto.ColumnType_STRING, Transform: transform.FromP(securityPolicyTurbotData, "Project"), Description: ColumnDescriptionProject},
 			{Name: "location", Type: proto.ColumnType_STRING, Transform: transform.FromConstant("global"), Description: ColumnDescriptionLocation},
 		},
 	}
 }
 
-//// LIST FUNCTION
+//// FETCH FUNCTIONS
 
 func listGcpComputeSecurityPolicies(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 
@@ -105,7 +105,8 @@ func listGcpComputeSecurityPolicies(ctx context.Context, d *plugin.QueryData, h 
 		d.WaitForListRateLimit(ctx)
 		for _, policy := range page.Items {
 			d.StreamListItem(ctx, policy)
-			//
+			// Check if context has been cancelled or if the limit has been hit (if specified)
+			// if there is a limit, it will return the number of rows required to reach this limit
 			if d.RowsRemaining(ctx) == 0 {
 				return nil
 			}
@@ -121,6 +122,7 @@ func listGcpComputeSecurityPolicies(ctx context.Context, d *plugin.QueryData, h 
 //// HYDRATE FUNCTIONS
 
 func getGcpComputeSecurityPolicy(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+	// Create Service Connection
 	service, err := ComputeService(ctx, d)
 	if err != nil {
 		return nil, err

--- a/gcp/table_gcp_compute_security_policy.go
+++ b/gcp/table_gcp_compute_security_policy.go
@@ -20,9 +20,11 @@ func tableGcpComputeSecurityPolicy(ctx context.Context) *plugin.Table {
 		Get: &plugin.GetConfig{
 			KeyColumns: plugin.SingleColumn("name"),
 			Hydrate:    getGcpComputeSecurityPolicy,
+			Tags:       map[string]string{"service": "compute", "action": "SecurityPolicies.Get"},
 		},
 		List: &plugin.ListConfig{
 			Hydrate: listGcpComputeSecurityPolicies,
+			Tags:    map[string]string{"service": "compute", "action": "SecurityPolicies.List"},
 		},
 		Columns: []*plugin.Column{
 			{Name: "name", Type: proto.ColumnType_STRING, Description: "The name of the security policy."},
@@ -48,7 +50,6 @@ func tableGcpComputeSecurityPolicy(ctx context.Context) *plugin.Table {
 //// LIST FUNCTION
 
 func listGcpComputeSecurityPolicies(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
-	plugin.Logger(ctx).Trace("listGcpComputeSecurityPolicies")
 
 	// Create Service Connection
 	service, err := ComputeService(ctx, d)

--- a/gcp/table_gcp_compute_security_policy.go
+++ b/gcp/table_gcp_compute_security_policy.go
@@ -2,6 +2,7 @@ package gcp
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	"github.com/turbot/go-kit/types"
@@ -16,33 +17,50 @@ import (
 func tableGcpComputeSecurityPolicy(ctx context.Context) *plugin.Table {
 	return &plugin.Table{
 		Name:        "gcp_compute_security_policy",
-		Description: "Google Cloud Armor Security Policy",
+		Description: "GCP Armor Security Policy",
 		Get: &plugin.GetConfig{
 			KeyColumns: plugin.SingleColumn("name"),
 			Hydrate:    getGcpComputeSecurityPolicy,
-			Tags:       map[string]string{"service": "compute", "action": "SecurityPolicies.Get"},
+			Tags:       map[string]string{"service": "compute", "action": "securityPolicies.get"},
 		},
 		List: &plugin.ListConfig{
 			Hydrate: listGcpComputeSecurityPolicies,
-			Tags:    map[string]string{"service": "compute", "action": "SecurityPolicies.List"},
+			KeyColumns: plugin.KeyColumnSlice{
+				{Name: "id", Require: plugin.Optional},
+				{Name: "type", Require: plugin.Optional},
+				{Name: "description", Require: plugin.Optional},
+				{Name: "self_link", Require: plugin.Optional},
+				{Name: "filter", Require: plugin.Optional, CacheMatch: "exact"},
+			},
+			Tags: map[string]string{"service": "compute", "action": "securityPolicies.list"},
 		},
 		Columns: []*plugin.Column{
 			{Name: "name", Type: proto.ColumnType_STRING, Description: "The name of the security policy."},
 			{Name: "id", Type: proto.ColumnType_INT, Description: "The unique identifier for the resource."},
+			{Name: "creation_timestamp", Type: proto.ColumnType_TIMESTAMP, Description: "Creation timestamp in RFC3339 text format."},
 			{Name: "description", Type: proto.ColumnType_STRING, Description: "An optional description of this resource."},
-			{Name: "self_link", Type: proto.ColumnType_STRING, Description: "The fully-qualified URL linking back to the resource."},
-			{Name: "fingerprint", Type: proto.ColumnType_STRING, Description: "Fingerprint of this resource. A hash of the contents stored in this object."},
-			{Name: "type", Type: proto.ColumnType_STRING, Description: "The type of the security policy."},
-			{Name: "rules", Type: proto.ColumnType_JSON, Description: "The set of rules that belong to this policy."},
-			{Name: "adaptive_protection_config", Type: proto.ColumnType_JSON, Description: "Configuration for adaptive protection."},
-			{Name: "advanced_options_config", Type: proto.ColumnType_JSON, Description: "Advanced options configuration."},
-			{Name: "recaptcha_options_config", Type: proto.ColumnType_JSON, Description: "reCAPTCHA options configuration."},
-			{Name: "labels", Type: proto.ColumnType_JSON, Description: "Labels to apply to this security policy."},
-			{Name: "label_fingerprint", Type: proto.ColumnType_STRING, Description: "Fingerprint of the labels."},
-			{Name: "project", Type: proto.ColumnType_STRING, Transform: transform.FromP(securityPolicyTurbotData, "Project"), Description: "The GCP Project ID."},
-			{Name: "location", Type: proto.ColumnType_STRING, Transform: transform.FromConstant("global"), Description: "The location for the resource. Always 'global' for security policies."},
-			{Name: "akas", Type: proto.ColumnType_JSON, Transform: transform.FromP(securityPolicyTurbotData, "Akas"), Description: "Array of globally unique identifier strings (also known as 'also known as' or 'akas')."},
-			{Name: "title", Type: proto.ColumnType_STRING, Transform: transform.FromField("Name"), Description: "Title of the resource."},
+			{Name: "self_link", Type: proto.ColumnType_STRING, Description: "Server-defined URL for the resource."},
+			{Name: "filter", Type: proto.ColumnType_STRING, Transform: transform.FromQual("filter"), Description: "The filter pattern for the search."},
+			{Name: "fingerprint", Type: proto.ColumnType_STRING, Description: "Specifies a fingerprint for this resource, which is essentially a hash of the metadata's contents and used for optimistic locking."},
+			{Name: "label_fingerprint", Type: proto.ColumnType_STRING, Description: "A fingerprint for the labels being applied to this security policy, which is essentially a hash of the labels set used for optimistic locking."},
+			{Name: "type", Type: proto.ColumnType_STRING, Description: "The type indicates the intended use of the security policy."},
+			{Name: "rules", Type: proto.ColumnType_JSON, Description: "A list of rules that belong to this policy."},
+			{Name: "adaptive_protection_config", Type: proto.ColumnType_JSON, Description: "Configuration settings for adaptive protection, which automatically detects and mitigates layer 7 DDoS attacks by analyzing traffic patterns and blocking suspicious requests."},
+			{Name: "advanced_options_config", Type: proto.ColumnType_JSON, Description: "Configuration for advanced security options, such as JSON parsing and custom header actions applied to requests evaluated by this security policy."},
+			{Name: "ddos_Protection_config", Type: proto.ColumnType_JSON, Description: "Configuration that enables or disables DDoS protection for the security policy, specifying the protection level against layer 7 volumetric attacks."},
+			{Name: "recaptcha_options_config", Type: proto.ColumnType_JSON, Description: "Configuration settings for Google reCAPTCHA Enterprise integration, including site keys and actions to take on failed reCAPTCHA challenges."},
+			{Name: "user_defined_fields", Type: proto.ColumnType_JSON, Description: "Definitions of user-defined fields for CLOUD_ARMOR_NETWORK policies."},
+			{Name: "force_send_fields", Type: proto.ColumnType_JSON, Description: "ForceSendFields is a list of field names (e.g. AdaptiveProtectionConfig) to unconditionally include in API requests."},
+			{Name: "labels", Type: proto.ColumnType_JSON, Description: "Labels for this resource."},
+
+			// standard steampipe columns
+			{Name: "title", Type: proto.ColumnType_STRING, Transform: transform.FromField("Name"), Description: ColumnDescriptionTitle},
+			{Name: "akas", Type: proto.ColumnType_JSON, Transform: transform.FromP(securityPolicyTurbotData, "Akas"), Description: ColumnDescriptionAkas},
+			{Name: "tags", Type: proto.ColumnType_JSON, Transform: transform.FromField("Labels"), Description: ColumnDescriptionTags},
+
+			// standard gcp columns
+			{Name: "project", Type: proto.ColumnType_STRING, Transform: transform.FromP(securityPolicyTurbotData, "Project"), Description: ColumnDescriptionProject},
+			{Name: "location", Type: proto.ColumnType_STRING, Transform: transform.FromConstant("global"), Description: ColumnDescriptionLocation},
 		},
 	}
 }
@@ -73,18 +91,28 @@ func listGcpComputeSecurityPolicies(ctx context.Context, d *plugin.QueryData, h 
 		}
 	}
 
-	resp := service.SecurityPolicies.List(project).MaxResults(*pageSize)
+	filter := ""
+
+	if d.EqualsQualString("filter") != "" {
+		filter = d.EqualsQualString("filter")
+	} else {
+		filter = buildComputeSecurityPolicyFilterParam(d.Quals)
+	}
+
+	resp := service.SecurityPolicies.List(project).MaxResults(*pageSize).Filter(filter)
 	if err := resp.Pages(ctx, func(page *compute.SecurityPolicyList) error {
 		// apply rate limiting
 		d.WaitForListRateLimit(ctx)
 		for _, policy := range page.Items {
 			d.StreamListItem(ctx, policy)
+			//
 			if d.RowsRemaining(ctx) == 0 {
 				return nil
 			}
 		}
 		return nil
 	}); err != nil {
+		plugin.Logger(ctx).Error("gcp_compute_security_policy.listGcpComputeSecurityPolicies", "api_error", err)
 		return nil, err
 	}
 	return nil, nil
@@ -117,6 +145,57 @@ func getGcpComputeSecurityPolicy(ctx context.Context, d *plugin.QueryData, h *pl
 	return policy, nil
 }
 
+//// UTILITY FUNCTION
+
+func buildComputeSecurityPolicyFilterParam(equalQuals plugin.KeyColumnQualMap) string {
+	filter := ""
+
+	filterQuals := []filterQualMap{
+		{"type", "type", "string"},
+		{"description", "description", "string"},
+		{"id", "id", "int"},
+		{"self_link", "selfLink", "string"},
+	}
+
+	for _, filterQualItem := range filterQuals {
+		filterQual := equalQuals[filterQualItem.ColumnName]
+		if filterQual == nil {
+			continue
+		}
+
+		// Check only if filter qual map matches with optional column name
+		if filterQual.Name == filterQualItem.ColumnName {
+			if filterQual.Quals == nil {
+				continue
+			}
+		}
+
+		for _, qual := range filterQual.Quals {
+			if qual.Value != nil {
+				value := qual.Value
+				switch filterQualItem.Type {
+				case "string":
+					if filter == "" {
+						filter = filterQualItem.PropertyPath + " = \"" + value.GetStringValue() + "\""
+					} else {
+						filter = filter + " AND " + filterQualItem.PropertyPath + " = \"" + value.GetStringValue() + "\""
+					}
+				case "int":
+					intVal := value.GetInt64Value()
+					if filter == "" {
+						filter = filterQualItem.PropertyPath + " = " + fmt.Sprintf("%d", intVal)
+					} else {
+						filter = filter + " AND " + filterQualItem.PropertyPath + " = " + fmt.Sprintf("%d", intVal)
+					}
+				}
+			}
+		}
+	}
+	return filter
+}
+
+////  TRANSFORM FUNCTION
+
 func securityPolicyTurbotData(_ context.Context, d *transform.TransformData) (interface{}, error) {
 	data := d.HydrateItem.(*compute.SecurityPolicy)
 	project := ""
@@ -128,7 +207,7 @@ func securityPolicyTurbotData(_ context.Context, d *transform.TransformData) (in
 	}
 	turbotData := map[string]interface{}{
 		"Project": project,
-		"Akas":    []string{"gcp://compute.googleapis.com" + data.SelfLink},
+		"Akas":    []string{"gcp://compute.googleapis.com/projects/" + project + "/global/securityPolicies/" + data.Name},
 	}
 	return turbotData[d.Param.(string)], nil
 }


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
Apply complete! Resources: 1 added, 0 changed, 0 destroyed.

Outputs:

fingerprint = "diSCF_wTb_8="
project_id = "nagraj-aaa"
resource_id = "projects/nagraj-aaa/global/securityPolicies/turbottest36080"
resource_name = "turbottest36080"
self_link = "https://www.googleapis.com/compute/v1/projects/nagraj-aaa/global/securityPolicies/turbottest36080"

Running SQL query: test-get-query.sql
[
  {
    "description": "Test security policy for validation.",
    "fingerprint": "diSCF_wTb_8=",
    "location": "global",
    "name": "turbottest36080",
    "project": "nagraj-aaa",
    "rules": [
      {
        "action": "allow",
        "description": "default rule",
        "headerAction": {},
        "kind": "compute#securityPolicyRule",
        "match": {
          "config": {
            "srcIpRanges": [
              "*"
            ]
          },
          "versionedExpr": "SRC_IPS_V1"
        },
        "priority": 2147483647
      }
    ],
    "self_link": "https://www.googleapis.com/compute/v1/projects/nagraj-aaa/global/securityPolicies/turbottest36080",
    "type": "CLOUD_ARMOR"
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "description": "Test security policy for validation.",
    "fingerprint": "diSCF_wTb_8=",
    "name": "turbottest36080",
    "self_link": "https://www.googleapis.com/compute/v1/projects/nagraj-aaa/global/securityPolicies/turbottest36080"
  }
]
✔ PASSED

POSTTEST: tests/gcp_compute_security_policy

TEARDOWN: tests/gcp_compute_security_policy

SUMMARY:

1/1 passed.


```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
> select
  name,
  id,
  description,
  self_link
from
  gcp_compute_security_policy;
+---------+---------------------------+-------------+-------------------------------------------------------------------------------------------+
| name    | id                        | description | self_link                                                                                 |
+---------+---------------------------+-------------+-------------------------------------------------------------------------------------------+
| test56  | 1,059,868,043,321,263,085 |             | https://www.googleapis.com/compute/v1/projects/nagraj-aaa/global/securityPolicies/test56  |
| test567 | 4,565,202,505,280,208,322 |             | https://www.googleapis.com/compute/v1/projects/nagraj-aaa/global/securityPolicies/test567 |
+---------+---------------------------+-------------+-------------------------------------------------------------------------------------------+
```

```
select
  name,
  id,
  description,
  rules,
  labels,
  project
from
  gcp_compute_security_policy
where
  name = 'test56';
+--------+---------------------------+-------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+--------+------------+
| name   | id                        | description | rules                                                                                                                                                                                                                                           | labels | project    |
+--------+---------------------------+-------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+--------+------------+
| test56 | 1,059,868,043,321,263,085 |             | [{"action":"deny(403)","description":"Default rule, higher priority overrides it","kind":"compute#securityPolicyRule","match":{"config":{"srcIpRanges":["*"]},"versionedExpr":"SRC_IPS_V1"},"preconfiguredWafConfig":{},"priority":2147483647}] | <null> | nagraj-aaa |
+--------+---------------------------+-------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+--------+------------+
```

```
select
  name,
  rules
from
  gcp_compute_security_policy;
+---------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| name    | rules                                                                                                                                                                                                                                           |
+---------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| test567 | [{"action":"deny(403)","description":"Default rule, higher priority overrides it","kind":"compute#securityPolicyRule","match":{"config":{"srcIpRanges":["*"]},"versionedExpr":"SRC_IPS_V1"},"preconfiguredWafConfig":{},"priority":2147483647}] |
| test56  | [{"action":"deny(403)","description":"Default rule, higher priority overrides it","kind":"compute#securityPolicyRule","match":{"config":{"srcIpRanges":["*"]},"versionedExpr":"SRC_IPS_V1"},"preconfiguredWafConfig":{},"priority":2147483647}] |
+---------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+

```

```
select
  name,
  adaptive_protection_config
from
  gcp_compute_security_policy
where
  adaptive_protection_config -> 'layer7DdosDefenseConfig' ->> 'enable' = 'true';
+--------+---------------------------------------------+
| name   | adaptive_protection_config                  |
+--------+---------------------------------------------+
| test56 | {"layer7DdosDefenseConfig":{"enable":true}} |
+--------+---------------------------------------------+
```
</details>
