### PR TITLE
Fix gcp_compute_ssl_policy table to return regional along with global SSL policies closes #772

### DIFF
--- a/gcp/compute_location_list.go
+++ b/gcp/compute_location_list.go
@@ -49,3 +49,42 @@ func BuildComputeLocationList(ctx context.Context, d *plugin.QueryData) []map[st
 	d.ConnectionManager.Cache.Set(locationCacheKey, matrix)
 	return matrix
 }
+
+// BuildComputeLocationListWithGlobal :: return a list of matrix items including global and all regions
+func BuildComputeLocationListWithGlobal(ctx context.Context, d *plugin.QueryData) []map[string]interface{} {
+	// have we already created and cached the locations?
+	locationCacheKey := "ComputeWithGlobal"
+	if cachedData, ok := d.ConnectionManager.Cache.Get(locationCacheKey); ok {
+		plugin.Logger(ctx).Trace("listlocationDetails:", cachedData.([]map[string]interface{}))
+		return cachedData.([]map[string]interface{})
+	}
+
+	// Create Service Connection
+	service, err := ComputeService(ctx, d)
+	if err != nil {
+		return nil
+	}
+
+	// Get project details
+	projectData, err := activeProject(ctx, d)
+	if err != nil {
+		return nil
+	}
+	project := projectData.Project
+
+	resp, err := service.Regions.List(project).Do()
+	if err != nil {
+		return nil
+	}
+
+	// Add global and all regions to the matrix
+	matrix := make([]map[string]interface{}, len(resp.Items)+1)
+	// Add global first
+	matrix[0] = map[string]interface{}{matrixKeyLocation: "global"}
+	// Then add all regions
+	for i, location := range resp.Items {
+		matrix[i+1] = map[string]interface{}{matrixKeyLocation: location.Name}
+	}
+	d.ConnectionManager.Cache.Set(locationCacheKey, matrix)
+	return matrix
+}


### PR DESCRIPTION


# Integration test logs
<details>
  <summary>Logs</summary>
  
```
Add passing integration test logs here
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
 select name, kind, creation_timestamp, location from gcp_compute_ssl_policy
+--------------------+-------------------+---------------------------+----------+
| name               | kind              | creation_timestamp        | location |
+--------------------+-------------------+---------------------------+----------+
| test-global-policy | compute#sslPolicy | 2025-07-23T00:18:50+05:30 | global   |
| test-policy        | compute#sslPolicy | 2025-07-23T00:12:19+05:30 | us-east1 |
+--------------------+-------------------+---------------------------+----------+
```
</details>
