### PR TITLE
Add table gcp_organization_audit_policy Closes #780

### DIFF
--- a/docs/tables/gcp_organization_audit_policy.md
+++ b/docs/tables/gcp_organization_audit_policy.md
@@ -36,7 +36,7 @@ from
   json_each(audit_log_configs);
 ```
 
-### List of services which has data write access
+### List of services that have data write access
 Determine the areas in which certain services have data write access. This is useful for understanding potential security risks and ensuring only appropriate services have this level of access.
 
 ```sql+postgres

--- a/docs/tables/gcp_organization_audit_policy.md
+++ b/docs/tables/gcp_organization_audit_policy.md
@@ -1,0 +1,120 @@
+---
+title: "Steampipe Table: gcp_organization_audit_policy - Query Google Cloud Platform Organization Audit Policies using SQL"
+description: "Allows users to query Organization Audit Policies in Google Cloud Platform, specifically the settings and configurations of all audit policies at the organization level, providing insights into compliance and security posture."
+folder: "Audit Policy"
+---
+
+# Table: gcp_organization_audit_policy - Query Google Cloud Platform Organization Audit Policies using SQL
+
+Google Cloud Audit Logs is a feature that maintains three audit logs for each Google Cloud project, folder, and organization: Admin Activity, Data Access, and System Event. These logs can be used to help you answer the question of "who did what, where, and when?" within your Google Cloud environment. Audit logs are critical for incident response, forensics, and establishing regulatory and compliance controls.
+
+## Table Usage Guide
+
+The `gcp_organization_audit_policy` table provides insights into audit policies within Google Cloud Platform organizations. As a security analyst, explore policy-specific details through this table, including policy settings, service conditions, and associated metadata. Utilize it to uncover information about policies, such as those with specific service conditions, the identity of the creator and the verification of policy settings.
+
+## Examples
+
+### Basic info
+
+Determine the areas in which different types of logs are created by analyzing the audit policies within the Google Cloud Platform organizations. This is useful for managing and understanding the audit trails in your environment.
+
+```sql+postgres
+select
+  organization_id,
+  service,
+  jsonb_array_elements(audit_log_configs) ->> 'logType' as log_type
+from
+  gcp_organization_audit_policy;
+```
+
+```sql+sqlite
+select
+  organization_id,
+  service,
+  json_extract(audit_log_configs, '$.logType') as log_type
+from
+  gcp_organization_audit_policy,
+  json_each(audit_log_configs);
+```
+
+### List of services which has data write access
+
+Determine the areas in which certain services have data write access. This is useful for understanding potential security risks and ensuring only appropriate services have this level of access.
+
+```sql+postgres
+select
+  organization_id,
+  service,
+  log_type ->> 'logType' as log_type
+from
+  gcp_organization_audit_policy,
+  jsonb_array_elements(audit_log_configs) as log_type
+where
+  log_type ->> 'logType' = 'DATA_WRITE';
+```
+
+```sql+sqlite
+select
+  organization_id,
+  service,
+  json_extract(log_type.value, '$.logType') as log_type
+from
+  gcp_organization_audit_policy,
+  json_each(audit_log_configs) as log_type
+where
+  json_extract(log_type.value, '$.logType') = 'DATA_WRITE';
+```
+
+### Get audit policy for a specific organization
+
+Retrieve audit policy details for a specific organization by its ID.
+
+```sql+postgres
+select
+  organization_id,
+  service,
+  audit_log_configs
+from
+  gcp_organization_audit_policy
+where
+  organization_id = '123456789';
+```
+
+```sql+sqlite
+select
+  organization_id,
+  service,
+  audit_log_configs
+from
+  gcp_organization_audit_policy
+where
+  organization_id = '123456789';
+```
+
+### List organizations with admin activity logging enabled
+
+Find organizations that have admin activity logging enabled for audit purposes.
+
+```sql+postgres
+select
+  organization_id,
+  service,
+  log_type ->> 'logType' as log_type
+from
+  gcp_organization_audit_policy,
+  jsonb_array_elements(audit_log_configs) as log_type
+where
+  log_type ->> 'logType' = 'ADMIN_READ';
+```
+
+```sql+sqlite
+select
+  organization_id,
+  service,
+  json_extract(log_type.value, '$.logType') as log_type
+from
+  gcp_organization_audit_policy,
+  json_each(audit_log_configs) as log_type
+where
+  json_extract(log_type.value, '$.logType') = 'ADMIN_READ';
+```

--- a/docs/tables/gcp_organization_audit_policy.md
+++ b/docs/tables/gcp_organization_audit_policy.md
@@ -15,7 +15,6 @@ The `gcp_organization_audit_policy` table provides insights into audit policies 
 ## Examples
 
 ### Basic info
-
 Determine the areas in which different types of logs are created by analyzing the audit policies within the Google Cloud Platform organizations. This is useful for managing and understanding the audit trails in your environment.
 
 ```sql+postgres
@@ -38,7 +37,6 @@ from
 ```
 
 ### List of services which has data write access
-
 Determine the areas in which certain services have data write access. This is useful for understanding potential security risks and ensuring only appropriate services have this level of access.
 
 ```sql+postgres
@@ -66,7 +64,6 @@ where
 ```
 
 ### Get audit policy for a specific organization
-
 Retrieve audit policy details for a specific organization by its ID.
 
 ```sql+postgres
@@ -92,7 +89,6 @@ where
 ```
 
 ### List organizations with admin activity logging enabled
-
 Find organizations that have admin activity logging enabled for audit purposes.
 
 ```sql+postgres

--- a/gcp/plugin.go
+++ b/gcp/plugin.go
@@ -78,6 +78,7 @@ func Plugin(ctx context.Context) *plugin.Plugin {
 			"gcp_app_engine_application":                              tableGcpAppEngineApplication(ctx),
 			"gcp_artifact_registry_repository":                        tableGcpArtifactRegistryRepository(ctx),
 			"gcp_audit_policy":                                        tableGcpAuditPolicy(ctx),
+			"gcp_organization_audit_policy":                           tableGcpOrganizationAuditPolicy(ctx),
 			"gcp_bigquery_dataset":                                    tableGcpBigQueryDataset(ctx),
 			"gcp_bigquery_job":                                        tableGcpBigQueryJob(ctx),
 			"gcp_bigquery_table":                                      tableGcpBigqueryTable(ctx),

--- a/gcp/table_gcp_organization_audit_policy.go
+++ b/gcp/table_gcp_organization_audit_policy.go
@@ -22,7 +22,7 @@ func tableGcpOrganizationAuditPolicy(_ context.Context) *plugin.Table {
 			KeyColumns: plugin.KeyColumnSlice{
 				{Name: "organization_id", Require: plugin.Optional},
 			},
-			Tags:          map[string]string{"service": "resourcemanager", "action": "organizations.getIamPolicy"},
+			Tags: map[string]string{"service": "resourcemanager", "action": "organizations.getIamPolicy"},
 		},
 		Columns: []*plugin.Column{
 			{

--- a/gcp/table_gcp_organization_audit_policy.go
+++ b/gcp/table_gcp_organization_audit_policy.go
@@ -34,7 +34,7 @@ func tableGcpOrganizationAuditPolicy(_ context.Context) *plugin.Table {
 			},
 			{
 				Name:        "audit_log_configs",
-				Description: "The configuration for logging of each type of permission",
+				Description: "The configuration for logging of each type of permission.",
 				Type:        proto.ColumnType_JSON,
 			},
 

--- a/gcp/table_gcp_organization_audit_policy.go
+++ b/gcp/table_gcp_organization_audit_policy.go
@@ -74,7 +74,10 @@ func listGcpOrganizationAuditPolicies(ctx context.Context, d *plugin.QueryData, 
 	resp, err := service.Organizations.GetIamPolicy("organizations/"+organizationId, &cloudresourcemanager.GetIamPolicyRequest{}).Context(ctx).Do()
 	
 	// apply rate limiting
+	// apply rate limiting
 	d.WaitForListRateLimit(ctx)
+
+	resp, err := service.Organizations.GetIamPolicy("organizations/"+organizationId, &cloudresourcemanager.GetIamPolicyRequest{}).Context(ctx).Do()
 	
 	if err != nil {
 		plugin.Logger(ctx).Error("listGcpOrganizationAuditPolicies", "organization_id", organizationId, "error", err)

--- a/gcp/table_gcp_organization_audit_policy.go
+++ b/gcp/table_gcp_organization_audit_policy.go
@@ -1,0 +1,115 @@
+package gcp
+
+import (
+	"context"
+
+	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
+
+	"google.golang.org/api/cloudresourcemanager/v1"
+)
+
+//// TABLE DEFINITION
+
+func tableGcpOrganizationAuditPolicy(_ context.Context) *plugin.Table {
+	return &plugin.Table{
+		Name:        "gcp_organization_audit_policy",
+		Description: "GCP Organization Audit Policy",
+		List: &plugin.ListConfig{
+			Hydrate:       listGcpOrganizationAuditPolicies,
+			ParentHydrate: listGCPOrganizations,
+			Tags:          map[string]string{"service": "resourcemanager", "action": "organizations.getIamPolicy"},
+		},
+		Columns: []*plugin.Column{
+			{
+				Name:        "organization_id",
+				Description: "The unique identifier for the organization.",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "service",
+				Description: "Specifies a service that will be enabled for audit logging",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "audit_log_configs",
+				Description: "The configuration for logging of each type of permission",
+				Type:        proto.ColumnType_JSON,
+			},
+
+			// standard steampipe columns
+			{
+				Name:        "akas",
+				Description: ColumnDescriptionAkas,
+				Type:        proto.ColumnType_JSON,
+				Hydrate:     organizationServiceNameToAkas,
+				Transform:   transform.FromValue(),
+			},
+
+			// standard gcp columns
+			{
+				Name:        "location",
+				Description: ColumnDescriptionLocation,
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromConstant("global"),
+			},
+		},
+	}
+}
+
+//// LIST FUNCTION
+
+func listGcpOrganizationAuditPolicies(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+	// Create Service Connection
+	service, err := CloudResourceManagerService(ctx, d)
+	if err != nil {
+		return nil, err
+	}
+
+	// Get the organization from the parent hydrate
+	organization := h.Item.(*cloudresourcemanager.Organization)
+	organizationId := getLastPathElement(organization.Name)
+
+	resp, err := service.Organizations.GetIamPolicy("organizations/"+organizationId, &cloudresourcemanager.GetIamPolicyRequest{}).Context(ctx).Do()
+	
+	// apply rate limiting
+	d.WaitForListRateLimit(ctx)
+	
+	if err != nil {
+		plugin.Logger(ctx).Error("listGcpOrganizationAuditPolicies", "organization_id", organizationId, "error", err)
+		return nil, err
+	}
+
+	for _, auditConfig := range resp.AuditConfigs {
+
+		// Add organization_id to the audit config for reference
+		auditConfigWithOrg := &OrganizationAuditConfig{
+			OrganizationId:  organizationId,
+			Service:         auditConfig.Service,
+			AuditLogConfigs: auditConfig.AuditLogConfigs,
+		}
+		d.StreamListItem(ctx, auditConfigWithOrg)
+
+		// Check if context has been cancelled or if the limit has been hit
+		if d.RowsRemaining(ctx) == 0 {
+			break
+		}
+	}
+
+	return nil, nil
+}
+
+func organizationServiceNameToAkas(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+	auditConfig := h.Item.(*OrganizationAuditConfig)
+
+	akas := []string{"gcp://cloudresourcemanager.googleapis.com/organizations/" + auditConfig.OrganizationId + "/services/" + auditConfig.Service}
+	return akas, nil
+}
+
+// OrganizationAuditConfig is a custom struct to include organization_id with audit config
+type OrganizationAuditConfig struct {
+	OrganizationId  string                                 `json:"organization_id"`
+	Service         string                                 `json:"service"`
+	AuditLogConfigs []*cloudresourcemanager.AuditLogConfig `json:"audit_log_configs"`
+}

--- a/gcp/table_gcp_organization_audit_policy.go
+++ b/gcp/table_gcp_organization_audit_policy.go
@@ -80,11 +80,10 @@ func listGcpOrganizationAuditPolicies(ctx context.Context, d *plugin.QueryData, 
 		return nil, nil
 	}
 
-	resp, err := service.Organizations.GetIamPolicy("organizations/"+organizationId, &cloudresourcemanager.GetIamPolicyRequest{}).Context(ctx).Do()
-
 	// apply rate limiting
 	d.WaitForListRateLimit(ctx)
 
+	resp, err := service.Organizations.GetIamPolicy("organizations/"+organizationId, &cloudresourcemanager.GetIamPolicyRequest{}).Context(ctx).Do()
 	if err != nil {
 		plugin.Logger(ctx).Error("gcp_organization_audit_policy.listGcpOrganizationAuditPolicies", "api_error", err)
 		return nil, err

--- a/gcp/table_gcp_organization_audit_policy.go
+++ b/gcp/table_gcp_organization_audit_policy.go
@@ -32,7 +32,7 @@ func tableGcpOrganizationAuditPolicy(_ context.Context) *plugin.Table {
 			},
 			{
 				Name:        "service",
-				Description: "Specifies a service that will be enabled for audit logging",
+				Description: "Specifies a service that will be enabled for audit logging.",
 				Type:        proto.ColumnType_STRING,
 			},
 			{


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
Add passing integration test logs here
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
> select
  organization_id,
  service,
  jsonb_array_elements(audit_log_configs) ->> 'logType' as log_type
from
  gcp_organization_audit_policy;
+-----------------+-------------+------------+
| organization_id | service     | log_type   |
+-----------------+-------------+------------+
| ************    | allServices | ADMIN_READ |
| ************    | allServices | DATA_READ  |
| ************    | allServices | DATA_WRITE |
+-----------------+-------------+------------+
> select
  organization_id,
  service,
  log_type ->> 'logType' as log_type
from
  gcp_organization_audit_policy,
  jsonb_array_elements(audit_log_configs) as log_type
where
  log_type ->> 'logType' = 'DATA_WRITE';
+-----------------+-------------+------------+
| organization_id | service     | log_type   |
+-----------------+-------------+------------+
| ************    | allServices | DATA_WRITE |
+-----------------+-------------+------------+
> select
  organization_id,
  service,
  audit_log_configs
from
  gcp_organization_audit_policy
where
  organization_id = '123456789';
+-----------------+---------+-------------------+
| organization_id | service | audit_log_configs |
+-----------------+---------+-------------------+
+-----------------+---------+-------------------+
> select
  organization_id,
  service,
  log_type ->> 'logType' as log_type
from
  gcp_organization_audit_policy,
  jsonb_array_elements(audit_log_configs) as log_type
where
  log_type ->> 'logType' = 'ADMIN_READ';
+-----------------+-------------+------------+
| organization_id | service     | log_type   |
+-----------------+-------------+------------+
| ************    | allServices | ADMIN_READ |
+-----------------+-------------+------------+
```
</details>
