### PR TITLE
Add table gcp_compute_service_attachment

### DIFF
--- a/gcp/plugin.go
+++ b/gcp/plugin.go
@@ -249,6 +249,7 @@ func Plugin(ctx context.Context) *plugin.Plugin {
 			"gcp_compute_snapshot":                                    tableGcpComputeSnapshot(ctx),
 			"gcp_compute_ssl_policy":                                  tableGcpComputeSslPolicy(ctx),
 			"gcp_compute_security_policy":                             tableGcpComputeSecurityPolicy(ctx),
+			"gcp_compute_service_attachment":                          tableGcpComputeServiceAttachment(ctx),
 			"gcp_compute_subnetwork":                                  tableGcpComputeSubnetwork(ctx),
 			"gcp_compute_target_https_proxy":                          tableGcpComputeTargetHttpsProxy(ctx),
 			"gcp_compute_target_pool":                                 tableGcpComputeTargetPool(ctx),

--- a/gcp/table_gcp_compute_service_attachment.go
+++ b/gcp/table_gcp_compute_service_attachment.go
@@ -1,0 +1,281 @@
+package gcp
+
+import (
+	"context"
+	"strings"
+
+	"github.com/turbot/go-kit/types"
+	"github.com/turbot/steampipe-plugin-sdk/v6/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin/transform"
+
+	compute "google.golang.org/api/compute/v0.beta"
+)
+
+//// TABLE DEFINITION
+
+func tableGcpComputeServiceAttachment(ctx context.Context) *plugin.Table {
+	return &plugin.Table{
+		Name:        "gcp_compute_service_attachment",
+		Description: "GCP Compute Service Attachment",
+		Get: &plugin.GetConfig{
+			KeyColumns: plugin.SingleColumn("name"),
+			Hydrate:    getComputeServiceAttachment,
+			Tags:       map[string]string{"service": "compute", "action": "serviceAttachments.get"},
+		},
+		List: &plugin.ListConfig{
+			Hydrate: listComputeServiceAttachments,
+			KeyColumns: plugin.KeyColumnSlice{
+				{Name: "connection_preference", Require: plugin.Optional, Operators: []string{"<>", "="}},
+				{Name: "enable_proxy_protocol", Require: plugin.Optional, Operators: []string{"<>", "="}},
+			},
+			Tags: map[string]string{"service": "compute", "action": "serviceAttachments.list"},
+		},
+		Columns: []*plugin.Column{
+			{
+				Name:        "name",
+				Description: "Name of the resource.",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "id",
+				Description: "The unique identifier for the resource.",
+				Type:        proto.ColumnType_INT,
+			},
+			{
+				Name:        "description",
+				Description: "An optional description of this resource.",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "kind",
+				Description: "The type of the resource.",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "region",
+				Description: "URL of the region where the service attachment resides.",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "self_link",
+				Description: "Server-defined URL for the resource.",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "creation_timestamp",
+				Description: "Creation timestamp in RFC3339 text format.",
+				Type:        proto.ColumnType_TIMESTAMP,
+			},
+			{
+				Name:        "connection_preference",
+				Description: "The connection preference of the service attachment (ACCEPT_AUTOMATIC, ACCEPT_MANUAL, or CONNECTION_PREFERENCE_UNSPECIFIED).",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "enable_proxy_protocol",
+				Description: "If true, enable the proxy protocol for client IP forwarding through proxies.",
+				Type:        proto.ColumnType_BOOL,
+			},
+			{
+				Name:        "fingerprint",
+				Description: "A hash of the contents stored in this object, used for optimistic locking.",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "producer_forwarding_rule",
+				Description: "URL of the internal load balancer forwarding rule serving the endpoint identified by this service attachment.",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "propagated_connection_limit",
+				Description: "The number of consumer spokes that connected PSC endpoints can be propagated to via Network Connectivity Center.",
+				Type:        proto.ColumnType_INT,
+			},
+			{
+				Name:        "psc_service_attachment_id",
+				Description: "An 128-bit global unique ID of the PSC service attachment.",
+				Type:        proto.ColumnType_JSON,
+			},
+			{
+				Name:        "reconcile_connections",
+				Description: "Whether a consumer accept/reject list change can reconcile statuses of existing PSC endpoints.",
+				Type:        proto.ColumnType_BOOL,
+			},
+			{
+				Name:        "target_service",
+				Description: "URL of a service serving the endpoint identified by this service attachment.",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "connected_endpoints",
+				Description: "An array of connections for all the consumers connected to this service attachment.",
+				Type:        proto.ColumnType_JSON,
+			},
+			{
+				Name:        "consumer_accept_lists",
+				Description: "Specifies which consumer projects or networks are allowed to connect to the service attachment.",
+				Type:        proto.ColumnType_JSON,
+			},
+			{
+				Name:        "consumer_reject_lists",
+				Description: "Specifies a list of projects or networks that are not allowed to connect to this service attachment.",
+				Type:        proto.ColumnType_JSON,
+			},
+			{
+				Name:        "domain_names",
+				Description: "Domain names used during integration between PSC connected endpoints and Cloud DNS.",
+				Type:        proto.ColumnType_JSON,
+			},
+			{
+				Name:        "nat_subnets",
+				Description: "URLs of subnets provided by the service producer to use for NAT in this service attachment.",
+				Type:        proto.ColumnType_JSON,
+			},
+			{
+				Name:        "tunneling_config",
+				Description: "Tunneling configuration that, when set, encapsulates traffic between consumer and producer.",
+				Type:        proto.ColumnType_JSON,
+			},
+
+			// standard steampipe columns
+			{
+				Name:        "title",
+				Description: ColumnDescriptionTitle,
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("Name"),
+			},
+			{
+				Name:        "akas",
+				Description: ColumnDescriptionAkas,
+				Type:        proto.ColumnType_JSON,
+				Transform:   transform.FromP(serviceAttachmentSelfLinkToTurbotData, "Akas"),
+			},
+
+			// standard gcp columns
+			{
+				Name:        "location",
+				Description: ColumnDescriptionLocation,
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("Region").Transform(lastPathElement),
+			},
+			{
+				Name:        "project",
+				Description: ColumnDescriptionProject,
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromP(serviceAttachmentSelfLinkToTurbotData, "Project"),
+			},
+		},
+	}
+}
+
+//// LIST FUNCTION
+
+func listComputeServiceAttachments(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+	service, err := ComputeBetaService(ctx, d)
+	if err != nil {
+		return nil, err
+	}
+
+	filterQuals := []filterQualMap{
+		{"connection_preference", "connectionPreference", "string"},
+		{"enable_proxy_protocol", "enableProxyProtocol", "boolean"},
+	}
+
+	filters := buildQueryFilterFromQuals(filterQuals, d.Quals)
+	filterString := ""
+	if len(filters) > 0 {
+		filterString = strings.Join(filters, " ")
+	}
+
+	pageSize := types.Int64(500)
+	limit := d.QueryContext.Limit
+	if d.QueryContext.Limit != nil {
+		if *limit < *pageSize {
+			pageSize = limit
+		}
+	}
+
+	projectId, err := getProject(ctx, d, h)
+	if err != nil {
+		return nil, err
+	}
+	project := projectId.(string)
+
+	resp := service.ServiceAttachments.AggregatedList(project).Filter(filterString).MaxResults(*pageSize)
+	if err := resp.Pages(ctx, func(page *compute.ServiceAttachmentAggregatedList) error {
+		d.WaitForListRateLimit(ctx)
+
+		for _, item := range page.Items {
+			for _, sa := range item.ServiceAttachments {
+				d.StreamListItem(ctx, sa)
+
+				if d.RowsRemaining(ctx) == 0 {
+					page.NextPageToken = ""
+					return nil
+				}
+			}
+		}
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+
+	return nil, err
+}
+
+//// HYDRATE FUNCTIONS
+
+func getComputeServiceAttachment(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+	service, err := ComputeBetaService(ctx, d)
+	if err != nil {
+		return nil, err
+	}
+
+	projectId, err := getProject(ctx, d, h)
+	if err != nil {
+		return nil, err
+	}
+	project := projectId.(string)
+
+	var found compute.ServiceAttachment
+	name := d.EqualsQuals["name"].GetStringValue()
+
+	resp := service.ServiceAttachments.AggregatedList(project).Filter("name=" + name)
+	if err := resp.Pages(
+		ctx,
+		func(page *compute.ServiceAttachmentAggregatedList) error {
+			for _, item := range page.Items {
+				for _, sa := range item.ServiceAttachments {
+					found = *sa
+				}
+			}
+			return nil
+		},
+	); err != nil {
+		return nil, err
+	}
+
+	if len(found.Name) < 1 {
+		return nil, nil
+	}
+
+	return &found, nil
+}
+
+//// TRANSFORM FUNCTIONS
+
+func serviceAttachmentSelfLinkToTurbotData(_ context.Context, d *transform.TransformData) (interface{}, error) {
+	sa := d.HydrateItem.(*compute.ServiceAttachment)
+	param := d.Param.(string)
+
+	project := strings.Split(sa.SelfLink, "/")[6]
+	region := getLastPathElement(types.SafeString(sa.Region))
+
+	turbotData := map[string]interface{}{
+		"Project": project,
+		"Akas":    []string{"gcp://compute.googleapis.com/projects/" + project + "/regions/" + region + "/serviceAttachments/" + sa.Name},
+	}
+
+	return turbotData[param], nil
+}


### PR DESCRIPTION
Adds a new table `gcp_compute_service_attachment` for surfacing GCP Private Service Connect (PSC) producer-side service attachments, including the consumer endpoints currently connected to each one. This is the GCP equivalent of the AWS plugin's `aws_vpc_endpoint_service` table.

## Motivation

Producer-side PSC observability — counting / inventorying customer endpoints connecting to a service attachment — is not currently expressible via this plugin. The only PSC-adjacent table today is `gcp_compute_forwarding_rule`, which is the *consumer* side and requires access to consumer projects (which a service producer typically does not have).

## What's in the table

Mirrors the [`compute.serviceAttachments` REST resource](https://cloud.google.com/compute/docs/reference/rest/beta/serviceAttachments) verbatim. Notable columns:

- `connected_endpoints` (JSON) — array of currently connected consumer endpoints (`status`, `endpoint`, `consumerNetwork`, `pscConnectionId`, etc.)
- `connection_preference` — `ACCEPT_AUTOMATIC` / `ACCEPT_MANUAL`
- `consumer_accept_lists`, `consumer_reject_lists` — allow/deny lists for ACCEPT_MANUAL
- `target_service`, `producer_forwarding_rule`, `nat_subnets`, `domain_names`, `enable_proxy_protocol`, etc.

Follows the same patterns as `gcp_compute_forwarding_rule`: `AggregatedList` across regions in `List`, single-name filtered aggregated list in `Get`, optional quals on `connection_preference` / `enable_proxy_protocol`.

# Integration test logs
<details>
  <summary>Logs</summary>

```
Not yet added — happy to add an integration test fixture analogous to gcp-test/tests/gcp_compute_forwarding_rule/ if maintainers want one for this draft. Will need guidance on the preferred shape since a service attachment with realistic `connected_endpoints` requires a corresponding consumer-side forwarding rule, which is more involved to set up via Terraform than a single-project resource.
```

</details>

# Example query results
<details>
  <summary>Results</summary>

```
> select name, region, connection_preference, jsonb_array_length(coalesce(connected_endpoints, '[]'::jsonb)) as endpoints from gcp_compute_service_attachment;
+----------+--------------------------------------------------------------------------------+-----------------------+-----------+
| name     | region                                                                         | connection_preference | endpoints |
+----------+--------------------------------------------------------------------------------+-----------------------+-----------+
| pl-z167n | https://www.googleapis.com/compute/beta/projects/<redacted>/regions/us-central1| ACCEPT_MANUAL         | 2         |
+----------+--------------------------------------------------------------------------------+-----------------------+-----------+

> select name, jsonb_pretty(connected_endpoints) from gcp_compute_service_attachment;
+----------+-----------------------------------------------------------------------------+
| name     | jsonb_pretty                                                                |
+----------+-----------------------------------------------------------------------------+
| pl-z167n | [                                                                           |
|          |   {                                                                         |
|          |     "status": "ACCEPTED",                                                   |
|          |     "endpoint": ".../projects/<consumer-1>/.../forwardingRules/<rule-1>",   |
|          |     "consumerNetwork": ".../projects/<consumer-1>/global/networks/<net>",   |
|          |     "pscConnectionId": "140010140106489858"                                 |
|          |   },                                                                        |
|          |   {                                                                         |
|          |     "status": "ACCEPTED",                                                   |
|          |     "endpoint": ".../projects/<consumer-2>/.../forwardingRules/<rule-2>",   |
|          |     "consumerNetwork": ".../projects/<consumer-2>/global/networks/<net>",   |
|          |     "pscConnectionId": "59700530921865220"                                  |
|          |   }                                                                         |
| ]                                                                                      |
+----------+-----------------------------------------------------------------------------+
```

Also verified empty-result behavior against a separate project with zero service attachments.
</details>

## Notes for reviewers

- Marked draft pending: (a) integration test fixture decision per above, (b) any feedback on the column set / naming.
- Schema is mirrored directly from `compute/v0.beta` SDK structs (the version already used by `gcp_compute_forwarding_rule`).